### PR TITLE
feat: Returns (RMA) workflow replaces SnowBell Return page

### DIFF
--- a/backend/app/__init__.py
+++ b/backend/app/__init__.py
@@ -78,12 +78,15 @@ def create_app():
         return response
 
     # Database connection string
+    if getattr(Config, 'TRUSTED_CONNECTION', 'no') == 'yes':
+        auth = "Trusted_Connection=yes;"
+    else:
+        auth = f"UID={Config.UID};PWD={Config.PWD};"
     app.config['CONN_STR'] = (
         f"DRIVER={Config.DRIVER};"
         f"SERVER={Config.SQL_SERVER};"
         f"DATABASE={Config.DATABASE};"
-        f"UID={Config.UID};"
-        f"PWD={Config.PWD};"
+        f"{auth}"
         f"TrustServerCertificate={Config.TRUST_CERT};"
     )
 
@@ -97,6 +100,7 @@ def create_app():
     from app.routes.images_rotes import images_bp
     from app.routes.report import report_bp
     from app.routes.xie.xie_routes import xie_bp
+    from app.routes.returns.returns_routes import returns_bp
 
     app.register_blueprint(auth_bp, url_prefix='/auth')
     app.register_blueprint(laptop_bp, url_prefix='/laptop')
@@ -105,6 +109,7 @@ def create_app():
     app.register_blueprint(images_bp, url_prefix='/images')
     app.register_blueprint(report_bp, url_prefix='/report')
     app.register_blueprint(xie_bp, url_prefix='/xie')
+    app.register_blueprint(returns_bp, url_prefix='/returns')
 
     app.logger.info('RMA Server startup')
 

--- a/backend/app/models.py
+++ b/backend/app/models.py
@@ -89,6 +89,49 @@ def get_shipping_label_image(tracking_number):
         files = sorted([f for f in os.listdir(image_dir) if os.path.isfile(os.path.join(image_dir, f))])
         return files
     return []
+
+
+# ============================================================
+# New "Returns" (RMA) workflow image storage.
+# Shared shipping-label photos live under images/returns_label/<label_ref>/
+# and per-unit photos under images/returns_unit/<item_id>/ so they can be
+# served by the existing /images/<type>/<id>/<filename> route.
+# ============================================================
+def _save_indexed_images(images, image_type, folder_id):
+    from werkzeug.utils import secure_filename
+
+    image_dir = os.path.join(get_modi_rma_root(), 'images', image_type, str(folder_id))
+    os.makedirs(image_dir, exist_ok=True)
+
+    existing = [f for f in os.listdir(image_dir) if os.path.isfile(os.path.join(image_dir, f))]
+    next_num = len(existing) + 1
+
+    saved = 0
+    for image in images:
+        if image and image.filename:
+            ext = os.path.splitext(secure_filename(image.filename))[1] or '.jpg'
+            filename = f"{next_num}{ext}"
+            image.save(os.path.join(image_dir, filename), buffer_size=1024 * 1024)
+            next_num += 1
+            saved += 1
+    return saved
+
+
+def save_returns_label_images(images, label_ref):
+    return _save_indexed_images(images, 'returns_label', label_ref)
+
+
+def save_returns_unit_images(images, item_id):
+    return _save_indexed_images(images, 'returns_unit', item_id)
+
+
+def get_returns_image_files(image_type, folder_id):
+    image_dir = os.path.join(get_modi_rma_root(), 'images', image_type, str(folder_id))
+    if os.path.isdir(image_dir):
+        return sorted(
+            [f for f in os.listdir(image_dir) if os.path.isfile(os.path.join(image_dir, f))]
+        )
+    return []
     # image_dir = os.path.join(get_modi_rma_root(), 'images', 'return_receiving')
     # if os.path.exists(image_dir):
     #     for filename in os.listdir(image_dir):

--- a/backend/app/routes/Auth.py
+++ b/backend/app/routes/Auth.py
@@ -1,4 +1,5 @@
 # app/routes/main_routes.py
+import pyodbc
 from flask import Blueprint, jsonify, request
 from werkzeug.security import generate_password_hash, check_password_hash
 from app.models import get_db_connection
@@ -42,18 +43,31 @@ def register():
     role = data.get('role', 'normal')
     department = data.get('department')
 
-    if not username or not password or not department:
-        return jsonify({"error": "Missing fields"}), 400
+    missing = [name for name, value in
+               (('username', username), ('password', password), ('department', department))
+               if not value]
+    if missing:
+        return jsonify({"error": f"Missing required fields: {', '.join(missing)}"}), 400
 
     password_hash = generate_password_hash(password)
 
-    conn = get_db_connection()
+    try:
+        conn = get_db_connection()
+    except Exception:
+        return jsonify({"error": "Unable to connect to the database. Please try again later."}), 500
+
     cursor = conn.cursor()
     try:
+        cursor.execute("SELECT 1 FROM RMA_users WHERE username = ?", (username,))
+        if cursor.fetchone():
+            return jsonify({"error": "Username already exists"}), 409
+
         cursor.execute("INSERT INTO RMA_users (username, password_hash, role, department) VALUES (?, ?, ?, ?)", (username, password_hash, role, department))
         conn.commit()
-    except:
-        return jsonify({"error": "Username already exists"}), 400
+    except pyodbc.IntegrityError:
+        return jsonify({"error": "Username already exists"}), 409
+    except Exception as e:
+        return jsonify({"error": f"Registration failed: {e}"}), 500
     finally:
         conn.close()
 

--- a/backend/app/routes/return_receiving_routes.py
+++ b/backend/app/routes/return_receiving_routes.py
@@ -34,8 +34,10 @@ def show_return_receiving_sheet():
         recorded_list = filters.get('recorded', [])
         order_number = filters.get('orderNumber', '').strip()
 
-        # Start query
-        query = "SELECT * FROM RMA_return_receiving WHERE 1=1"
+        # Start query.
+        # Exclude rows owned by the new parallel "Returns (RMA)" feature
+        # (Source = 'RETURNS'); those are managed by the /returns blueprint.
+        query = "SELECT * FROM RMA_return_receiving WHERE (Source IS NULL OR Source <> 'RETURNS')"
         params = []
 
         if tracking_number:
@@ -93,7 +95,10 @@ def api_get_return_receiving_detail(tracking_number):
     try:
         conn = get_db_connection()
         cursor = conn.cursor()
-        cursor.execute("SELECT * FROM RMA_return_receiving WHERE TrackingNumber = ?", tracking_number)
+        cursor.execute(
+            "SELECT * FROM RMA_return_receiving WHERE TrackingNumber = ? AND (Source IS NULL OR Source <> 'RETURNS')",
+            tracking_number,
+        )
         row = cursor.fetchone()
         if not row:
             return jsonify({"error": "Not found"}), 404

--- a/backend/app/routes/returns/returns_routes.py
+++ b/backend/app/routes/returns/returns_routes.py
@@ -1,0 +1,694 @@
+"""
+Returns (RMA) workflow — Python/Flask port of the Snowbell RMA Google Apps
+Script. This is a NEW, parallel feature that reuses the RMA_return_receiving
+table (extended with extra columns by
+backend/migrations/2026-07_add_returns_columns.sql). Every row it owns is
+tagged Source = 'RETURNS' so the existing /return feature is untouched.
+
+Concept mapping vs. the Apps Script:
+  - Google Sheet rows   -> RMA_return_receiving rows where Source = 'RETURNS'
+  - Google Drive images -> local filesystem (served by the /images blueprint)
+  - CacheService list    -> not needed; SQL handles the reads directly
+"""
+
+import os
+import random
+import re
+from datetime import datetime
+
+from flask import Blueprint, request, jsonify, current_app
+
+from app.models import (
+    db_connection,
+    get_db_connection,
+    get_modi_rma_root,
+    save_returns_label_images,
+    save_returns_unit_images,
+    get_returns_image_files,
+)
+
+returns_bp = Blueprint('returns', __name__)
+
+SOURCE = 'RETURNS'
+
+FILENO_PREFIX = 'sid-'
+FILENO_PAD = 4
+SHIP_PREFIX = 'ship.'
+SHIP_PAD = 4
+
+_FILENO_RE = re.compile(r'^' + re.escape(FILENO_PREFIX) + r'(\d+)$', re.IGNORECASE)
+_SHIP_RE = re.compile(r'^' + re.escape(SHIP_PREFIX) + r'(\d+)$', re.IGNORECASE)
+
+
+# ------------------------------------------------------------------
+# Helpers
+# ------------------------------------------------------------------
+def _fmt_date(value):
+    """Format a DATE/DATETIME value as 'YYYY-MM-DD', or '' when empty."""
+    if value is None or value == '':
+        return ''
+    if isinstance(value, datetime):
+        return value.strftime('%Y-%m-%d')
+    if hasattr(value, 'strftime'):  # datetime.date
+        return value.strftime('%Y-%m-%d')
+    s = str(value)
+    return s[:10] if len(s) >= 10 else s
+
+
+def _iso_timestamp(value):
+    if value is None or value == '':
+        return ''
+    if hasattr(value, 'isoformat'):
+        return value.isoformat()
+    return str(value)
+
+
+def _s(value):
+    return '' if value is None else str(value)
+
+
+def _next_item_ids(cursor, count):
+    cursor.execute(
+        "SELECT ISNULL(MAX(ItemID), 0) FROM RMA_return_receiving WHERE Source = ?",
+        (SOURCE,),
+    )
+    base = cursor.fetchone()[0] or 0
+    return [base + i for i in range(1, count + 1)]
+
+
+def _next_file_nos(cursor, count):
+    cursor.execute(
+        "SELECT FileNo FROM RMA_return_receiving WHERE Source = ? AND FileNo IS NOT NULL",
+        (SOURCE,),
+    )
+    max_n = 0
+    for (file_no,) in cursor.fetchall():
+        m = _FILENO_RE.match(_s(file_no))
+        if m:
+            n = int(m.group(1))
+            if n > max_n:
+                max_n = n
+    return [f"{FILENO_PREFIX}{str(max_n + i).zfill(FILENO_PAD)}" for i in range(1, count + 1)]
+
+
+def _next_ship_batch_id(cursor):
+    cursor.execute(
+        "SELECT ShipBatch FROM RMA_return_receiving WHERE Source = ? AND ShipBatch IS NOT NULL",
+        (SOURCE,),
+    )
+    max_n = 0
+    for (batch,) in cursor.fetchall():
+        m = _SHIP_RE.match(_s(batch))
+        if m:
+            n = int(m.group(1))
+            if n > max_n:
+                max_n = n
+    return f"{SHIP_PREFIX}{str(max_n + 1).zfill(SHIP_PAD)}"
+
+
+def _make_group_id(timestamp):
+    def b36(num):
+        if num == 0:
+            return '0'
+        digits = '0123456789abcdefghijklmnopqrstuvwxyz'
+        out = ''
+        while num > 0:
+            num, rem = divmod(num, 36)
+            out = digits[rem] + out
+        return out
+
+    t = b36(int(timestamp.timestamp() * 1000))
+    rand = b36(random.randint(0, 36 * 36 - 1)).rjust(2, '0')
+    return 'g_' + t + rand
+
+
+# ------------------------------------------------------------------
+# Submit — create one row per unit (Apps Script submitReturn)
+# ------------------------------------------------------------------
+@returns_bp.route('/submit', methods=['POST'])
+def submit_return():
+    try:
+        tracking = (request.form.get('tracking') or '').strip()
+        received_date = (request.form.get('receivedDate') or '').strip() or None
+        remark = (request.form.get('remark') or '').strip()
+
+        try:
+            quantity = int(request.form.get('quantity', '1'))
+        except (TypeError, ValueError):
+            quantity = 1
+        if quantity < 1:
+            quantity = 1
+
+        # Per-unit laptop names: unit_laptop_0, unit_laptop_1, ...
+        laptop_names = []
+        for i in range(quantity):
+            name = (request.form.get(f'unit_laptop_{i}') or '').strip()
+            if not name:
+                name = (request.form.get('laptop') or '').strip()
+            laptop_names.append(name)
+
+        timestamp = datetime.now()
+        group_id = _make_group_id(timestamp) if quantity > 1 else None
+
+        with db_connection() as conn:
+            cursor = conn.cursor()
+            item_ids = _next_item_ids(cursor, quantity)
+            file_nos = _next_file_nos(cursor, quantity)
+            label_ref = item_ids[0]
+
+            for idx in range(quantity):
+                cursor.execute(
+                    """
+                    INSERT INTO RMA_return_receiving
+                        (TrackingNumber, Remark, CreationDateTime, Source,
+                         ItemID, LabelRef, LaptopName, ReceivedDate, Quantity,
+                         GroupID, UnitIndex, FileNo)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        tracking,
+                        remark,
+                        timestamp,
+                        SOURCE,
+                        item_ids[idx],
+                        label_ref,
+                        laptop_names[idx],
+                        received_date,
+                        1,
+                        group_id,
+                        (idx + 1) if quantity > 1 else None,
+                        file_nos[idx],
+                    ),
+                )
+
+        # Images are saved outside the DB transaction (filesystem writes).
+        label_images = [img for img in request.files.getlist('images') if img and img.filename]
+        shared_count = save_returns_label_images(label_images, label_ref)
+
+        unit_image_counts = []
+        for idx in range(quantity):
+            unit_imgs = [
+                img for img in request.files.getlist(f'unit_images_{idx}')
+                if img and img.filename
+            ]
+            unit_image_counts.append(save_returns_unit_images(unit_imgs, item_ids[idx]))
+
+        current_app.logger.info(
+            "Returns submit | tracking=%s | qty=%d | ids=%s",
+            tracking, quantity, item_ids,
+        )
+
+        return jsonify({
+            'status': 'success',
+            'ids': item_ids,
+            'id': item_ids[0],
+            'fileNos': file_nos,
+            'fileNo': file_nos[0],
+            'groupId': group_id or '',
+            'quantity': quantity,
+            'sharedImageCount': shared_count,
+            'unitImageCounts': unit_image_counts,
+        })
+    except Exception as e:
+        current_app.logger.exception("Returns submit failed")
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+
+
+# ------------------------------------------------------------------
+# List (Apps Script getReturns / readListFromSheet_)
+# ------------------------------------------------------------------
+@returns_bp.route('/list', methods=['GET'])
+def list_returns():
+    conn = None
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT ItemID, CreationDateTime, TrackingNumber, LaptopName, ReceivedDate,
+                   InspectionDate, Pallet, Serial, UnitIndex, GroupID,
+                   ShipDate, ShipBatch, BulkType, FileNo
+            FROM RMA_return_receiving
+            WHERE Source = ?
+            ORDER BY ItemID DESC
+            """,
+            (SOURCE,),
+        )
+        rows = cursor.fetchall()
+
+        # groupSize per GroupID
+        group_sizes = {}
+        for r in rows:
+            g = _s(r.GroupID)
+            if g:
+                group_sizes[g] = group_sizes.get(g, 0) + 1
+
+        # One directory scan up front instead of a filesystem check per row —
+        # only items that actually have an image folder get a per-folder listing.
+        unit_image_root = os.path.join(get_modi_rma_root(), 'images', 'returns_unit')
+        folders_with_images = set(os.listdir(unit_image_root)) if os.path.isdir(unit_image_root) else set()
+
+        items = []
+        for r in rows:
+            group_id = _s(r.GroupID)
+            unit_image_count = (
+                len(get_returns_image_files('returns_unit', r.ItemID))
+                if str(r.ItemID) in folders_with_images
+                else 0
+            )
+            items.append({
+                'id': _s(r.ItemID),
+                'timestamp': _iso_timestamp(r.CreationDateTime),
+                'tracking': _s(r.TrackingNumber),
+                'laptop': _s(r.LaptopName),
+                'receivedDate': _fmt_date(r.ReceivedDate),
+                'inspectionDate': _fmt_date(r.InspectionDate),
+                'pallet': _s(r.Pallet),
+                'serials': _s(r.Serial).strip(),
+                'unitIndex': '' if r.UnitIndex is None else _s(r.UnitIndex),
+                'groupSize': group_sizes.get(group_id, '') if group_id else '',
+                'unitImageCount': unit_image_count,
+                'shipDate': _fmt_date(r.ShipDate),
+                'shipBatch': _s(r.ShipBatch),
+                'bulkType': _s(r.BulkType),
+                'fileNo': _s(r.FileNo),
+            })
+
+        return jsonify({'status': 'success', 'items': items})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+    finally:
+        if conn:
+            conn.close()
+
+
+# ------------------------------------------------------------------
+# Detail (Apps Script getReturnById)
+# ------------------------------------------------------------------
+def _image_urls(image_type, folder_id):
+    files = get_returns_image_files(image_type, folder_id)
+    return [f"/images/{image_type}/{folder_id}/{fn}" for fn in files]
+
+
+@returns_bp.route('/<item_id>', methods=['GET'])
+def get_return_detail(item_id):
+    conn = None
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+
+        row = None
+        # A numeric id is an ItemID; anything else (e.g. a scanned File No
+        # like "sid-0001") skips the int lookup to avoid a SQL conversion error.
+        if str(item_id).isdigit():
+            cursor.execute(
+                "SELECT * FROM RMA_return_receiving WHERE Source = ? AND ItemID = ?",
+                (SOURCE, int(item_id)),
+            )
+            row = cursor.fetchone()
+        # Fallback: accept a File No (printed barcode).
+        if not row:
+            cursor.execute(
+                "SELECT * FROM RMA_return_receiving WHERE Source = ? AND FileNo = ?",
+                (SOURCE, str(item_id)),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return jsonify({'status': 'error', 'message': 'ID not found: ' + str(item_id)}), 404
+
+        cols = [c[0] for c in cursor.description]
+        rec = dict(zip(cols, row))
+        group_id = _s(rec.get('GroupID'))
+
+        siblings = []
+        if group_id:
+            cursor.execute(
+                """
+                SELECT ItemID, FileNo, UnitIndex, LaptopName, InspectionDate
+                FROM RMA_return_receiving
+                WHERE Source = ? AND GroupID = ? AND ItemID <> ?
+                """,
+                (SOURCE, group_id, rec['ItemID']),
+            )
+            for s in cursor.fetchall():
+                siblings.append({
+                    'id': _s(s.ItemID),
+                    'fileNo': _s(s.FileNo),
+                    'unitIndex': '' if s.UnitIndex is None else _s(s.UnitIndex),
+                    'laptop': _s(s.LaptopName),
+                    'inspectionDate': _fmt_date(s.InspectionDate),
+                })
+
+            def sort_key(sib):
+                try:
+                    return (0, int(sib['unitIndex']))
+                except (ValueError, TypeError):
+                    return (1, 0)
+            siblings.sort(key=sort_key)
+
+        group_size = (len(siblings) + 1) if group_id else 1
+        serial = _s(rec.get('Serial')).strip()
+
+        item = {
+            'id': _s(rec.get('ItemID')),
+            'timestamp': _iso_timestamp(rec.get('CreationDateTime')),
+            'tracking': _s(rec.get('TrackingNumber')),
+            'laptop': _s(rec.get('LaptopName')),
+            'receivedDate': _fmt_date(rec.get('ReceivedDate')),
+            'remark': _s(rec.get('Remark')),
+            'inspectionDate': _fmt_date(rec.get('InspectionDate')),
+            'pallet': _s(rec.get('Pallet')),
+            'quantity': '' if rec.get('Quantity') is None else _s(rec.get('Quantity')),
+            'serial': serial,
+            'serials': [serial] if serial else [],
+            'images': _image_urls('returns_label', rec.get('LabelRef') or rec.get('ItemID')),
+            'unitImages': _image_urls('returns_unit', rec.get('ItemID')),
+            'groupId': group_id,
+            'unitIndex': '' if rec.get('UnitIndex') is None else _s(rec.get('UnitIndex')),
+            'groupSize': str(group_size),
+            'siblings': siblings,
+            'inspectionRemark': _s(rec.get('InspectionRemark')),
+            'shipDate': _fmt_date(rec.get('ShipDate')),
+            'shipBatch': _s(rec.get('ShipBatch')),
+            'bulkType': _s(rec.get('BulkType')),
+            'fileNo': _s(rec.get('FileNo')),
+        }
+        return jsonify({'status': 'success', 'item': item})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+    finally:
+        if conn:
+            conn.close()
+
+
+# ------------------------------------------------------------------
+# Inspection (Apps Script updateInspection)
+# ------------------------------------------------------------------
+@returns_bp.route('/inspection', methods=['POST'])
+def update_inspection():
+    try:
+        payload = request.get_json(silent=True) or {}
+        inspection_date = (payload.get('inspectionDate') or '').strip()
+        if not inspection_date:
+            return jsonify({'status': 'error', 'message': 'Inspection date is required.'}), 400
+
+        serial = (payload.get('serial') or '').strip()
+        if not serial:
+            return jsonify({'status': 'error', 'message': 'Serial number is required.'}), 400
+
+        item_id = payload.get('id')
+        pallet = (payload.get('pallet') or '').strip()
+        inspection_remark = (payload.get('inspectionRemark') or '').strip()
+
+        with db_connection() as conn:
+            cursor = conn.cursor()
+
+            cursor.execute(
+                "SELECT ItemID FROM RMA_return_receiving WHERE Source = ? AND ItemID = ?",
+                (SOURCE, item_id),
+            )
+            if not cursor.fetchone():
+                return jsonify({'status': 'error', 'message': 'ID not found: ' + str(item_id)}), 404
+
+            # Serial must be unique across other units.
+            cursor.execute(
+                """
+                SELECT TOP 1 ItemID FROM RMA_return_receiving
+                WHERE Source = ? AND ItemID <> ? AND LOWER(LTRIM(RTRIM(Serial))) = ?
+                """,
+                (SOURCE, item_id, serial.lower()),
+            )
+            dup = cursor.fetchone()
+            if dup:
+                return jsonify({
+                    'status': 'error',
+                    'message': f"Serial '{serial}' is already assigned to {dup.ItemID}.",
+                }), 400
+
+            cursor.execute(
+                """
+                UPDATE RMA_return_receiving
+                SET InspectionDate = ?, Pallet = ?, Serial = ?, InspectionRemark = ?
+                WHERE Source = ? AND ItemID = ?
+                """,
+                (inspection_date, pallet, serial, inspection_remark, SOURCE, item_id),
+            )
+
+        return jsonify({'status': 'success', 'id': item_id, 'serial': serial})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+
+
+# ------------------------------------------------------------------
+# Bulk type (Apps Script updateBulkType) — applies to whole tracking #
+# ------------------------------------------------------------------
+@returns_bp.route('/bulk-type', methods=['POST'])
+def update_bulk_type():
+    try:
+        payload = request.get_json(silent=True) or {}
+        item_id = payload.get('id')
+        new_value = payload.get('bulkType') or ''
+
+        with db_connection() as conn:
+            cursor = conn.cursor()
+            cursor.execute(
+                "SELECT TrackingNumber FROM RMA_return_receiving WHERE Source = ? AND ItemID = ?",
+                (SOURCE, item_id),
+            )
+            row = cursor.fetchone()
+            if not row:
+                return jsonify({'status': 'error', 'message': 'ID not found: ' + str(item_id)}), 404
+
+            tracking = _s(row.TrackingNumber).strip()
+            if tracking:
+                cursor.execute(
+                    """
+                    UPDATE RMA_return_receiving SET BulkType = ?
+                    WHERE Source = ? AND LTRIM(RTRIM(TrackingNumber)) = ?
+                    """,
+                    (new_value, SOURCE, tracking),
+                )
+                updated = cursor.rowcount
+            else:
+                cursor.execute(
+                    "UPDATE RMA_return_receiving SET BulkType = ? WHERE Source = ? AND ItemID = ?",
+                    (new_value, SOURCE, item_id),
+                )
+                updated = cursor.rowcount
+
+        return jsonify({
+            'status': 'success',
+            'bulkType': new_value,
+            'tracking': tracking,
+            'updatedCount': updated,
+        })
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+
+
+# ------------------------------------------------------------------
+# Ship-out: pallet summary (Apps Script getPalletSummary)
+# ------------------------------------------------------------------
+@returns_bp.route('/pallets', methods=['GET'])
+def pallet_summary():
+    conn = None
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT Pallet, InspectionDate, ShipDate
+            FROM RMA_return_receiving
+            WHERE Source = ? AND Pallet IS NOT NULL AND LTRIM(RTRIM(Pallet)) <> ''
+            """,
+            (SOURCE,),
+        )
+        by_pallet = {}
+        for r in cursor.fetchall():
+            pallet = _s(r.Pallet).strip()
+            if not pallet:
+                continue
+            bucket = by_pallet.setdefault(pallet, {'pallet': pallet, 'total': 0, 'ready': 0, 'shipped': 0})
+            bucket['total'] += 1
+            if r.ShipDate:
+                bucket['shipped'] += 1
+            elif r.InspectionDate:
+                bucket['ready'] += 1
+
+        pallets = sorted(by_pallet.values(), key=lambda p: _natural_key(p['pallet']))
+        return jsonify({'status': 'success', 'pallets': pallets})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+    finally:
+        if conn:
+            conn.close()
+
+
+def _natural_key(s):
+    return [int(t) if t.isdigit() else t.lower() for t in re.split(r'(\d+)', str(s))]
+
+
+@returns_bp.route('/pallets/<pallet>/units', methods=['GET'])
+def units_by_pallet(pallet):
+    conn = None
+    try:
+        target = (pallet or '').strip()
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT ItemID, FileNo, LaptopName, Serial, InspectionDate, ShipDate, ShipBatch
+            FROM RMA_return_receiving
+            WHERE Source = ? AND LTRIM(RTRIM(Pallet)) = ?
+            """,
+            (SOURCE, target),
+        )
+        units = []
+        for r in cursor.fetchall():
+            units.append({
+                'id': _s(r.ItemID),
+                'fileNo': _s(r.FileNo),
+                'laptop': _s(r.LaptopName),
+                'serial': _s(r.Serial),
+                'inspectionDate': _fmt_date(r.InspectionDate),
+                'shipDate': _fmt_date(r.ShipDate),
+                'shipBatch': _s(r.ShipBatch),
+            })
+        units.sort(key=lambda u: _natural_key(u['id']))
+        return jsonify({'status': 'success', 'units': units})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+    finally:
+        if conn:
+            conn.close()
+
+
+# ------------------------------------------------------------------
+# Ship units (Apps Script shipUnits)
+# ------------------------------------------------------------------
+@returns_bp.route('/ship', methods=['POST'])
+def ship_units():
+    try:
+        payload = request.get_json(silent=True) or {}
+        ship_date = (payload.get('shipDate') or '').strip()
+        if not ship_date:
+            return jsonify({'status': 'error', 'message': 'Ship date is required.'}), 400
+
+        unit_ids = [str(u) for u in (payload.get('unitIds') or [])]
+        pallet_filter = (payload.get('pallet') or '').strip()
+
+        if not pallet_filter and not unit_ids:
+            return jsonify({'status': 'error', 'message': 'Specify either a pallet or unit IDs.'}), 400
+
+        with db_connection() as conn:
+            cursor = conn.cursor()
+
+            if unit_ids:
+                placeholders = ','.join(['?'] * len(unit_ids))
+                cursor.execute(
+                    f"""
+                    SELECT ItemID, InspectionDate, ShipDate
+                    FROM RMA_return_receiving
+                    WHERE Source = ? AND ItemID IN ({placeholders})
+                    """,
+                    (SOURCE, *unit_ids),
+                )
+            else:
+                cursor.execute(
+                    """
+                    SELECT ItemID, InspectionDate, ShipDate
+                    FROM RMA_return_receiving
+                    WHERE Source = ? AND LTRIM(RTRIM(Pallet)) = ?
+                    """,
+                    (SOURCE, pallet_filter),
+                )
+
+            target_ids = []
+            skipped = []
+            for r in cursor.fetchall():
+                if r.ShipDate:
+                    skipped.append({'id': _s(r.ItemID), 'reason': 'already shipped'})
+                elif not r.InspectionDate:
+                    skipped.append({'id': _s(r.ItemID), 'reason': 'not inspected'})
+                else:
+                    target_ids.append(_s(r.ItemID))
+
+            if not target_ids:
+                msg = 'Nothing to ship.'
+                if skipped:
+                    msg += ' Skipped: ' + ', '.join(f"{s['id']} ({s['reason']})" for s in skipped)
+                return jsonify({'status': 'error', 'message': msg}), 400
+
+            batch_id = _next_ship_batch_id(cursor)
+            placeholders = ','.join(['?'] * len(target_ids))
+            cursor.execute(
+                f"""
+                UPDATE RMA_return_receiving
+                SET ShipDate = ?, ShipBatch = ?
+                WHERE Source = ? AND ItemID IN ({placeholders})
+                """,
+                (ship_date, batch_id, SOURCE, *target_ids),
+            )
+
+        return jsonify({
+            'status': 'success',
+            'batchId': batch_id,
+            'shipped': target_ids,
+            'shippedCount': len(target_ids),
+            'skipped': skipped,
+        })
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+
+
+# ------------------------------------------------------------------
+# Monthly report (Apps Script getMonthlyReport)
+# ------------------------------------------------------------------
+@returns_bp.route('/report', methods=['GET'])
+def monthly_report():
+    conn = None
+    try:
+        conn = get_db_connection()
+        cursor = conn.cursor()
+        cursor.execute(
+            """
+            SELECT ReceivedDate, InspectionDate, ShipDate
+            FROM RMA_return_receiving
+            WHERE Source = ?
+            """,
+            (SOURCE,),
+        )
+
+        buckets = {}
+
+        def bump(key, field):
+            if not key:
+                return
+            b = buckets.setdefault(key, {'received': 0, 'inspected': 0, 'shipped': 0})
+            b[field] += 1
+
+        def month_key(value):
+            d = _fmt_date(value)
+            return d[:7] if len(d) >= 7 else ''
+
+        for r in cursor.fetchall():
+            bump(month_key(r.ReceivedDate), 'received')
+            bump(month_key(r.InspectionDate), 'inspected')
+            bump(month_key(r.ShipDate), 'shipped')
+
+        months = [
+            {'month': k, **buckets[k]}
+            for k in sorted(buckets.keys(), reverse=True)
+        ]
+        totals = {'received': 0, 'inspected': 0, 'shipped': 0}
+        for m in months:
+            totals['received'] += m['received']
+            totals['inspected'] += m['inspected']
+            totals['shipped'] += m['shipped']
+
+        return jsonify({'status': 'success', 'months': months, 'totals': totals})
+    except Exception as e:
+        return jsonify({'status': 'error', 'message': str(e)}), 500
+    finally:
+        if conn:
+            conn.close()

--- a/backend/config.py
+++ b/backend/config.py
@@ -7,6 +7,18 @@ class Config:
     DRIVER = "{ODBC Driver 18 for SQL Server}"
     TRUST_CERT = "yes"
     MODI_RMA_DIR = "/vol1/1001/RMA"
+
+# config.py for local development (Windows auth against SQL Server Express;
+# run backend/migrations/local_dev_bootstrap.sql first)
+# class Config:
+#     SQL_SERVER = r"localhost\SQLEXPRESS"
+#     DATABASE = "RMA"
+#     UID = ""
+#     PWD = ""
+#     TRUSTED_CONNECTION = "yes"
+#     DRIVER = "{ODBC Driver 18 for SQL Server}"
+#     TRUST_CERT = "yes"
+#     MODI_RMA_DIR = "/vol1/1001/RMA"
     
 # config.py for testing purposes
 # class Config:

--- a/backend/migrations/2026-07_add_returns_columns.sql
+++ b/backend/migrations/2026-07_add_returns_columns.sql
@@ -1,0 +1,97 @@
+/* ============================================================
+   Migration: extend RMA_return_receiving for the new "Returns" (RMA)
+   workflow ported from the Snowbell RMA Google Apps Script.
+
+   This is a NEW, parallel feature. It reuses the existing
+   RMA_return_receiving table (as requested) but adds nullable columns
+   so the current /return feature keeps working unchanged.
+
+   Rows created by the new feature are tagged Source = 'RETURNS'.
+   Rows from the old feature keep Source = NULL. The new API only ever
+   reads/writes rows where Source = 'RETURNS'.
+
+   Safe to run multiple times (each column is added only if missing).
+
+   Column mapping (Google Script "Returns" sheet -> SQL column):
+     ID              -> ItemID          (sequential per-unit number)
+     Timestamp       -> CreationDateTime (existing column, reused)
+     Tracking #      -> TrackingNumber   (existing column, reused)
+     Laptop Name     -> LaptopName
+     Received Date   -> ReceivedDate
+     Remark          -> Remark           (existing column, reused)
+     Images          -> stored on disk   (images/returns_label/<LabelRef>)
+     Inspection Date -> InspectionDate
+     Pallet          -> Pallet
+     Quantity        -> Quantity
+     Serial Numbers  -> Serial
+     Group ID        -> GroupID
+     Unit Index      -> UnitIndex
+     Unit Images     -> stored on disk   (images/returns_unit/<ItemID>)
+     Insp. Remark    -> InspectionRemark
+     Ship Date       -> ShipDate
+     Ship Batch ID   -> ShipBatch
+     Bulk Type       -> BulkType
+     File No         -> FileNo
+   ============================================================ */
+
+SET NOCOUNT ON;
+
+IF COL_LENGTH('RMA_return_receiving', 'Source') IS NULL
+    ALTER TABLE RMA_return_receiving ADD Source NVARCHAR(20) NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'ItemID') IS NULL
+    ALTER TABLE RMA_return_receiving ADD ItemID INT NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'LabelRef') IS NULL
+    ALTER TABLE RMA_return_receiving ADD LabelRef INT NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'LaptopName') IS NULL
+    ALTER TABLE RMA_return_receiving ADD LaptopName NVARCHAR(255) NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'ReceivedDate') IS NULL
+    ALTER TABLE RMA_return_receiving ADD ReceivedDate DATE NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'InspectionDate') IS NULL
+    ALTER TABLE RMA_return_receiving ADD InspectionDate DATE NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'Pallet') IS NULL
+    ALTER TABLE RMA_return_receiving ADD Pallet NVARCHAR(100) NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'Quantity') IS NULL
+    ALTER TABLE RMA_return_receiving ADD Quantity INT NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'Serial') IS NULL
+    ALTER TABLE RMA_return_receiving ADD Serial NVARCHAR(255) NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'GroupID') IS NULL
+    ALTER TABLE RMA_return_receiving ADD GroupID NVARCHAR(50) NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'UnitIndex') IS NULL
+    ALTER TABLE RMA_return_receiving ADD UnitIndex INT NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'InspectionRemark') IS NULL
+    ALTER TABLE RMA_return_receiving ADD InspectionRemark NVARCHAR(MAX) NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'ShipDate') IS NULL
+    ALTER TABLE RMA_return_receiving ADD ShipDate DATE NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'ShipBatch') IS NULL
+    ALTER TABLE RMA_return_receiving ADD ShipBatch NVARCHAR(50) NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'BulkType') IS NULL
+    ALTER TABLE RMA_return_receiving ADD BulkType NVARCHAR(50) NULL;
+
+IF COL_LENGTH('RMA_return_receiving', 'FileNo') IS NULL
+    ALTER TABLE RMA_return_receiving ADD FileNo NVARCHAR(50) NULL;
+GO
+
+/* Speeds up the per-unit lookups the new API does most often. */
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_RMA_return_receiving_ItemID')
+    CREATE INDEX IX_RMA_return_receiving_ItemID
+        ON RMA_return_receiving (ItemID) WHERE ItemID IS NOT NULL;
+GO
+
+IF NOT EXISTS (SELECT 1 FROM sys.indexes WHERE name = 'IX_RMA_return_receiving_Source')
+    CREATE INDEX IX_RMA_return_receiving_Source
+        ON RMA_return_receiving (Source);
+GO

--- a/backend/migrations/local_dev_bootstrap.sql
+++ b/backend/migrations/local_dev_bootstrap.sql
@@ -1,0 +1,120 @@
+﻿/* ============================================================
+   Local development bootstrap for the RMA database.
+
+   Creates the RMA database and every table the backend queries,
+   with columns inferred from the SQL statements in backend/app.
+   Safe to run multiple times (everything is IF-NOT-EXISTS guarded).
+
+   After running this, also run 2026-07_add_returns_columns.sql to
+   add the "Returns" workflow columns to RMA_return_receiving.
+
+   Usage (Windows auth against localhost\SQLEXPRESS):
+     sqlcmd -S localhost\SQLEXPRESS -E -i local_dev_bootstrap.sql
+   ============================================================ */
+
+IF DB_ID('RMA') IS NULL
+    CREATE DATABASE RMA;
+GO
+
+USE RMA;
+GO
+
+-- Users (Auth.py)
+IF OBJECT_ID('RMA_users', 'U') IS NULL
+CREATE TABLE RMA_users (
+    id            INT IDENTITY(1,1) PRIMARY KEY,
+    username      NVARCHAR(100) NOT NULL UNIQUE,
+    password_hash NVARCHAR(512) NOT NULL,
+    role          NVARCHAR(50)  NOT NULL DEFAULT 'normal',
+    department    NVARCHAR(50)  NOT NULL
+);
+GO
+
+-- Return receiving (return_receiving_routes.py; base columns only --
+-- the Returns-workflow columns come from 2026-07_add_returns_columns.sql
+IF OBJECT_ID('RMA_return_receiving', 'U') IS NULL
+CREATE TABLE RMA_return_receiving (
+    ID               INT IDENTITY(1,1) PRIMARY KEY,
+    TrackingNumber   NVARCHAR(255),
+    OrderNumber      NVARCHAR(255),
+    Company          NVARCHAR(255),
+    Code             NVARCHAR(50),
+    Remark           NVARCHAR(MAX),
+    Recorded         BIT,
+    CreationDateTime DATETIME DEFAULT GETDATE()
+);
+GO
+
+-- Laptops (routes/laptop/, report.py)
+IF OBJECT_ID('RMA_laptop_sheet', 'U') IS NULL
+CREATE TABLE RMA_laptop_sheet (
+    ID                   INT IDENTITY(1,1) PRIMARY KEY,
+    Brand                NVARCHAR(255),
+    Model                NVARCHAR(255),
+    Spec                 NVARCHAR(255),
+    UpDatedSpec          NVARCHAR(255),
+    SerialNumber         NVARCHAR(255),
+    OdooRef              NVARCHAR(255),
+    Condition            NVARCHAR(50),
+    Sealed               BIT,
+    Stock                NVARCHAR(50),
+    OrderNumber          NVARCHAR(255),
+    Remark               NVARCHAR(MAX),
+    OdooRecord           BIT,
+    TechDone             BIT,
+    TechDoneDate         DATETIME,
+    SaleDate             DATETIME,
+    LastModifiedUser     NVARCHAR(100),
+    LastModifiedDateTime DATETIME,
+    InputDate            DATETIME,
+    InputUser            NVARCHAR(100)
+);
+GO
+
+-- Non-laptop items (routes/non_laptop/, report.py)
+IF OBJECT_ID('RMA_non_laptop_sheet', 'U') IS NULL
+CREATE TABLE RMA_non_laptop_sheet (
+    ID                   INT IDENTITY(1,1) PRIMARY KEY,
+    TrackingNumber       NVARCHAR(255),
+    Category             NVARCHAR(255),
+    Name                 NVARCHAR(255),
+    OdooRef              NVARCHAR(255),
+    SKU                  NVARCHAR(255),
+    Condition            NVARCHAR(50),
+    ReceivedDate         DATE,
+    OdooRecord           NVARCHAR(10),
+    Remark               NVARCHAR(MAX),
+    Location             NVARCHAR(255),
+    OrderNumber          NVARCHAR(255),
+    SaleDate             DATETIME,
+    InspectionRequest    NVARCHAR(10),
+    ReadyToSale          BIT,
+    OrderDistributed     BIT,
+    LastModifiedUser     NVARCHAR(100),
+    LastModifiedDateTime DATETIME,
+    InputDate            DATETIME
+);
+GO
+
+-- Xie laptop returns (routes/xie/xie_routes.py)
+IF OBJECT_ID('xie_laptop_return', 'U') IS NULL
+CREATE TABLE xie_laptop_return (
+    id                     INT IDENTITY(1,1) PRIMARY KEY,
+    order_number           NVARCHAR(255),
+    tracking_number        NVARCHAR(255),
+    laptop_name            NVARCHAR(255),
+    customer_name          NVARCHAR(255),
+    remark                 NVARCHAR(MAX),
+    serial_number          NVARCHAR(255),
+    return_id              NVARCHAR(50),
+    condition              NVARCHAR(100),
+    location               NVARCHAR(255),
+    tracking_received_date DATE,
+    inspection_date        DATE,
+    delivery_date          DATE,
+    last_modified_user     NVARCHAR(100),
+    last_modified_datetime DATETIME,
+    return_type            NVARCHAR(50)
+);
+GO
+

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -23,6 +23,11 @@ import ReturnReceivingList from "./components/ReturnReceiving/ReturnReceivingLis
 import ReturnReceivingInput from "./components/ReturnReceiving/ReturnReceivingInput";
 import ReturnReceivingDetails from "./components/ReturnReceiving/ReturnReceivingDetails";
 import ReturnReceivingEdit from "./components/ReturnReceiving/ReturnReceivingEdit";
+import ReturnsList from "./components/Returns/ReturnsList";
+import ReturnsInput from "./components/Returns/ReturnsInput";
+import ReturnsDetail from "./components/Returns/ReturnsDetail";
+import ReturnsShipOut from "./components/Returns/ReturnsShipOut";
+import ReturnsReport from "./components/Returns/ReturnsReport";
 import XieList from "./components/Xie/XieList";
 import XieInput from "./components/Xie/XieInput";
 import XieDetails from './components/Xie/XieDetails';
@@ -160,6 +165,26 @@ function App() {
                   <Navigate to="/" />
                 )
               }
+            />
+            <Route
+              path="/returns"
+              element={isAuthenticated ? <ReturnsList /> : <Navigate to="/" />}
+            />
+            <Route
+              path="/returns/input"
+              element={isAuthenticated ? <ReturnsInput /> : <Navigate to="/" />}
+            />
+            <Route
+              path="/returns/ship"
+              element={isAuthenticated ? <ReturnsShipOut /> : <Navigate to="/" />}
+            />
+            <Route
+              path="/returns/report"
+              element={isAuthenticated ? <ReturnsReport /> : <Navigate to="/" />}
+            />
+            <Route
+              path="/returns/:id"
+              element={isAuthenticated ? <ReturnsDetail /> : <Navigate to="/" />}
             />
             <Route
               path="/xie"

--- a/frontend/src/components/Dashboard.js
+++ b/frontend/src/components/Dashboard.js
@@ -29,9 +29,9 @@ function Dashboard({ role, department, onLogout }) {
               Return Receiving
             </button>
           </Link>
-          <Link to="/xie">
+          <Link to="/returns">
             <button className="w-full bg-purple-500 text-white p-4 rounded-lg hover:bg-purple-600 transition-colors">
-              SnowBell Return
+              Returns (RMA)
             </button>
           </Link>
           {role === "manager" && (

--- a/frontend/src/components/Returns/ReturnsDetail.js
+++ b/frontend/src/components/Returns/ReturnsDetail.js
@@ -1,0 +1,361 @@
+import React, { useEffect, useRef, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import { ClipLoader } from "react-spinners";
+import copy from "copy-to-clipboard";
+import Toast from "../common/Toast";
+
+const API = `http://${window.location.hostname}:8088`;
+
+// Lazy-load JsBarcode from CDN (matches the original Apps Script approach,
+// so no npm dependency is required).
+let barcodePromise = null;
+function loadJsBarcode() {
+  if (window.JsBarcode) return Promise.resolve(window.JsBarcode);
+  if (!barcodePromise) {
+    barcodePromise = new Promise((resolve, reject) => {
+      const s = document.createElement("script");
+      s.src = "https://cdn.jsdelivr.net/npm/jsbarcode@3.11.6/dist/JsBarcode.all.min.js";
+      s.onload = () => resolve(window.JsBarcode);
+      s.onerror = () => reject(new Error("barcode library failed to load"));
+      document.body.appendChild(s);
+    });
+  }
+  return barcodePromise;
+}
+
+function formatTimestamp(ts) {
+  if (!ts) return "";
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return String(ts);
+  return d.toLocaleString();
+}
+
+function ReturnsDetail() {
+  const { id } = useParams();
+  const navigate = useNavigate();
+  const [item, setItem] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [toast, setToast] = useState(null);
+  const [saving, setSaving] = useState(false);
+  const barcodeRef = useRef(null);
+
+  // inspection form state
+  const [inspectionDate, setInspectionDate] = useState("");
+  const [pallet, setPallet] = useState("");
+  const [serial, setSerial] = useState("");
+  const [inspectionRemark, setInspectionRemark] = useState("");
+
+  const load = () => {
+    setLoading(true);
+    fetch(`${API}/returns/${encodeURIComponent(id)}`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.status === "success") {
+          setItem(data.item);
+          // Default the inspection date to today so a fresh inspection is one scan + save.
+          setInspectionDate(data.item.inspectionDate || new Date().toISOString().slice(0, 10));
+          setPallet(data.item.pallet || "");
+          setSerial(data.item.serial || "");
+          setInspectionRemark(data.item.inspectionRemark || "");
+        } else {
+          setError(data.message || "Not found");
+        }
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(String(err));
+        setLoading(false);
+      });
+  };
+
+  useEffect(load, [id]);
+
+  // Existing pallets as suggestions for the inspection form.
+  const [palletOptions, setPalletOptions] = useState([]);
+  useEffect(() => {
+    fetch(`${API}/returns/pallets`)
+      .then((r) => r.json())
+      .then((res) => {
+        if (res.status === "success") {
+          setPalletOptions((res.pallets || []).map((p) => p.pallet).filter(Boolean));
+        }
+      })
+      .catch(() => {});
+  }, []);
+
+  useEffect(() => {
+    if (!item || !item.fileNo || !barcodeRef.current) return;
+    loadJsBarcode()
+      .then((JsBarcode) => {
+        try {
+          JsBarcode(barcodeRef.current, item.fileNo, {
+            format: "CODE128", width: 2, height: 60, displayValue: true, fontSize: 14, margin: 6,
+          });
+        } catch (e) { /* ignore render error */ }
+      })
+      .catch(() => {});
+  }, [item]);
+
+  const saveBulkType = (value) => {
+    fetch(`${API}/returns/bulk-type`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ id: item.id, bulkType: value }),
+    })
+      .then((r) => r.json())
+      .then((res) => {
+        if (res.status === "success") {
+          setItem((prev) => ({ ...prev, bulkType: res.bulkType }));
+          const n = res.updatedCount || 1;
+          setToast({ message: n > 1 ? `Bulk type set for ${n} units` : "Bulk type saved", type: "success" });
+        } else setToast({ message: res.message || "Save failed", type: "error" });
+      })
+      .catch((err) => setToast({ message: "Save failed: " + err, type: "error" }));
+  };
+
+  const saveInspection = () => {
+    if (!inspectionDate) return setToast({ message: "Inspection date is required.", type: "error" });
+    if (!serial.trim()) return setToast({ message: "Serial number is required.", type: "error" });
+    setSaving(true);
+    fetch(`${API}/returns/inspection`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        id: item.id, inspectionDate, pallet: pallet.trim(), serial: serial.trim(), inspectionRemark: inspectionRemark.trim(),
+      }),
+    })
+      .then((r) => r.json())
+      .then((res) => {
+        setSaving(false);
+        if (res.status === "success") {
+          setToast({ message: "Inspection saved", type: "success" });
+          load();
+        } else setToast({ message: res.message || "Save failed", type: "error" });
+      })
+      .catch((err) => { setSaving(false); setToast({ message: "Save failed: " + err, type: "error" }); });
+  };
+
+  if (loading) return <div className="p-6 flex justify-center"><ClipLoader color="#4B5563" size={40} /></div>;
+  if (error) return <div className="max-w-3xl mx-auto p-6"><div className="bg-white p-6 rounded-lg text-red-800">{error}</div></div>;
+
+  const Row = ({ label, children }) => (
+    <>
+      <div className="text-gray-500 font-semibold">{label}</div>
+      <div className="text-gray-800 break-words">{children || "—"}</div>
+    </>
+  );
+
+  const Copyable = ({ value }) =>
+    value ? (
+      <span
+        onClick={() => {
+          let copied = false;
+          try {
+            copied = copy(value);
+          } catch {
+            copied = false;
+          }
+          if (copied) setToast({ message: `Copied: ${value}`, type: "success" });
+        }}
+        title="Click to copy"
+        className="cursor-pointer hover:bg-gray-200 rounded px-0.5"
+      >
+        {value}
+      </span>
+    ) : null;
+
+  // Print just the barcode label (bars + File No), nothing else: no page
+  // title, and @page margin 0 suppresses the browser's header/footer text.
+  const printBarcode = () => {
+    const svg = barcodeRef.current ? barcodeRef.current.outerHTML : "";
+    if (!svg) return;
+    const w = window.open("", "_blank", "width=420,height=260");
+    if (!w) return;
+    w.document.write(
+      "<html><head><title> </title>" +
+      "<style>@page{margin:0}html,body{margin:0;height:100%}" +
+      "body{display:flex;align-items:center;justify-content:center}</style>" +
+      "</head><body>" + svg +
+      "<script>window.onafterprint=function(){window.close()};</" + "script>" +
+      "</body></html>"
+    );
+    w.document.close();
+    w.focus();
+    w.print();
+  };
+
+  const allSiblings = [
+    ...(item.siblings || []),
+    { id: item.id, fileNo: item.fileNo, unitIndex: item.unitIndex, laptop: item.laptop, inspectionDate: item.inspectionDate, current: true },
+  ].sort((a, b) => {
+    const ai = parseInt(a.unitIndex, 10), bi = parseInt(b.unitIndex, 10);
+    if (isNaN(ai) && isNaN(bi)) return 0;
+    if (isNaN(ai)) return 1;
+    if (isNaN(bi)) return -1;
+    return ai - bi;
+  });
+
+  const card = "bg-white rounded-lg shadow-sm p-6 mb-4";
+
+  return (
+    <>
+      {toast && <Toast {...toast} onClose={() => setToast(null)} />}
+      <div className="max-w-3xl mx-auto p-5">
+        <button
+          onClick={() => navigate("/returns")}
+          className="mb-4 bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600"
+        >
+          Back
+        </button>
+
+        <div className={card}>
+          <h1 className="text-2xl font-bold mb-1 flex items-center gap-2.5 flex-wrap">
+            Return{" "}
+            <span
+              className="font-mono text-base font-bold text-purple-800 bg-purple-100 px-3 py-1 rounded cursor-pointer hover:bg-purple-200"
+              title="Click to copy"
+              onClick={() => {
+                let copied = false;
+                try {
+                  copied = copy(item.fileNo || "");
+                } catch {
+                  copied = false;
+                }
+                if (copied) setToast({ message: `Copied: ${item.fileNo}`, type: "success" });
+              }}
+            >
+              {item.fileNo || "—"}
+            </span>
+            <span
+              className={`text-xs font-semibold px-2 py-1 rounded ${
+                item.shipDate
+                  ? "bg-purple-100 text-purple-800"
+                  : item.inspectionDate
+                  ? "bg-green-100 text-green-800"
+                  : "bg-yellow-100 text-yellow-800"
+              }`}
+            >
+              {item.shipDate ? "Shipped" : item.inspectionDate ? "Inspected" : "Pending inspection"}
+            </span>
+          </h1>
+          <div className="grid grid-cols-[140px_1fr] gap-y-2 gap-x-3.5 text-sm mt-3">
+            <Row label="Tracking #"><Copyable value={item.tracking} /></Row>
+            <Row label="Laptop">{item.laptop}</Row>
+            <Row label="Received">{item.receivedDate}</Row>
+            <Row label="Submitted">{formatTimestamp(item.timestamp)}</Row>
+            {item.bulkType && <Row label="Bulk type">{item.bulkType}</Row>}
+            {item.inspectionDate ? (
+              <>
+                <Row label="Inspection">{item.inspectionDate}</Row>
+                {item.pallet && <Row label="Pallet">{item.pallet}</Row>}
+                {item.serial && <Row label="Serial #"><Copyable value={item.serial} /></Row>}
+                {item.inspectionRemark && <Row label="Insp. remark">{item.inspectionRemark}</Row>}
+              </>
+            ) : (
+              <Row label="Inspection"><span className="text-amber-800 bg-amber-100 px-1.5 py-0.5 rounded text-xs">Pending</span></Row>
+            )}
+            {item.shipDate && (
+              <>
+                <Row label="Shipped">{item.shipDate}</Row>
+                {item.shipBatch && <Row label="Ship batch">{item.shipBatch}</Row>}
+              </>
+            )}
+            {item.remark && <Row label="Submit remark">{item.remark}</Row>}
+          </div>
+        </div>
+
+        <div className={card}>
+          <h2 className="text-base font-bold text-gray-700 mb-3">File No Barcode</h2>
+          <div className="text-center">
+            <svg ref={barcodeRef} />
+            <div>
+              <button onClick={printBarcode} className="mt-2 bg-white border border-gray-300 px-3.5 py-1.5 rounded text-sm font-semibold hover:bg-gray-50">🖨 Print label</button>
+            </div>
+          </div>
+        </div>
+
+        {allSiblings.length > 1 && (
+          <div className={card}>
+            <h2 className="text-base font-bold text-gray-700 mb-3">Units in this shipment ({item.groupSize})</h2>
+            <div className="flex flex-col gap-1.5">
+              {allSiblings.map((sib) => (
+                <div
+                  key={sib.id}
+                  onClick={() => !sib.current && navigate(`/returns/${encodeURIComponent(sib.id)}`)}
+                  className={`flex items-center gap-2.5 px-3 py-2.5 border rounded-lg text-sm ${sib.current ? "bg-purple-50 border-purple-200" : "border-gray-200 hover:bg-gray-50 cursor-pointer"}`}
+                >
+                  <span className="font-mono font-bold text-purple-800">{sib.fileNo || sib.id}</span>
+                  {sib.unitIndex && <span className="text-gray-500">Unit {sib.unitIndex}</span>}
+                  {sib.laptop && <span className="text-gray-500">{sib.laptop}</span>}
+                  <span className={`ml-auto text-xs ${sib.inspectionDate ? "text-emerald-700" : "text-amber-800"}`}>
+                    {sib.inspectionDate ? "✓ Inspected" : "Pending"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+
+        <div className={card}>
+          <h2 className="text-base font-bold text-gray-700 mb-3">Bulk type</h2>
+          <div className="flex gap-2 flex-wrap">
+            {["New Bulk", "Old Bulk"].map((opt) => (
+              <button
+                key={opt}
+                onClick={() => saveBulkType(opt)}
+                className={`flex-1 min-w-[120px] text-center px-3 py-2.5 border rounded text-sm font-semibold ${item.bulkType === opt ? "border-purple-800 bg-purple-100 text-purple-800" : "border-gray-300 bg-white text-gray-600 hover:bg-gray-50"}`}
+              >
+                {opt}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div className={card}>
+          <h2 className="text-base font-bold text-gray-700 mb-3">Inspection</h2>
+          <label className="block text-sm font-bold text-gray-700 mb-1">Inspection date</label>
+          <input type="date" value={inspectionDate} onChange={(e) => setInspectionDate(e.target.value)} className="w-full p-2.5 border border-gray-300 rounded text-sm mb-3.5" />
+          <label className="block text-sm font-bold text-gray-700 mb-1">Pallet</label>
+          <input type="text" value={pallet} onChange={(e) => setPallet(e.target.value)} placeholder="e.g. P-12" list="pallet-options" className="w-full p-2.5 border border-gray-300 rounded text-sm mb-3.5" />
+          <datalist id="pallet-options">
+            {palletOptions.map((p) => (
+              <option key={p} value={p} />
+            ))}
+          </datalist>
+          <label className="block text-sm font-bold text-gray-700 mb-1">Serial number</label>
+          <input type="text" value={serial} onChange={(e) => setSerial(e.target.value)} placeholder="Scan or type serial #" className="w-full p-2.5 border border-gray-300 rounded text-sm mb-3.5" />
+          <label className="block text-sm font-bold text-gray-700 mb-1">Inspection remark</label>
+          <textarea value={inspectionRemark} onChange={(e) => setInspectionRemark(e.target.value)} placeholder="Notes from inspection (optional)" className="w-full p-2.5 border border-gray-300 rounded text-sm mb-3.5 min-h-[64px]" />
+          <button onClick={saveInspection} disabled={saving} className="w-full bg-blue-600 text-white py-2.5 rounded font-semibold hover:bg-blue-700 disabled:opacity-60">
+            {saving ? "Saving…" : "Save inspection"}
+          </button>
+        </div>
+
+        <ImagesCard title="Photos of this unit" empty="No unit-specific photos." urls={item.unitImages} />
+        <ImagesCard title="Label / shipment photos" empty="No shipment photos." urls={item.images} />
+      </div>
+    </>
+  );
+}
+
+function ImagesCard({ title, empty, urls }) {
+  return (
+    <div className="bg-white rounded-lg shadow-sm p-6 mb-4">
+      <h2 className="text-base font-bold text-gray-700 mb-3">{title}</h2>
+      {urls && urls.length ? (
+        <div className="grid gap-2.5" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(130px, 1fr))" }}>
+          {urls.map((u, i) => (
+            <a key={i} href={`${API}${u}`} target="_blank" rel="noopener noreferrer" className="block rounded-lg overflow-hidden border border-gray-200 aspect-square">
+              <img src={`${API}${u}`} alt="" loading="lazy" className="w-full h-full object-cover" />
+            </a>
+          ))}
+        </div>
+      ) : (
+        <div className="text-gray-400 text-sm italic">{empty}</div>
+      )}
+    </div>
+  );
+}
+
+export default ReturnsDetail;

--- a/frontend/src/components/Returns/ReturnsInput.js
+++ b/frontend/src/components/Returns/ReturnsInput.js
@@ -1,0 +1,272 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Toast from "../common/Toast";
+
+const API = `http://${window.location.hostname}:8088`;
+const MAX_DIMENSION = 1200;
+
+// Resize/compress an image file to a JPEG under ~1200px wide before upload.
+function resizeImage(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onload = () => {
+        try {
+          const scale = Math.min(1, MAX_DIMENSION / img.width);
+          const canvas = document.createElement("canvas");
+          canvas.width = Math.max(1, Math.round(img.width * scale));
+          canvas.height = Math.max(1, Math.round(img.height * scale));
+          canvas.getContext("2d").drawImage(img, 0, 0, canvas.width, canvas.height);
+          canvas.toBlob(
+            (blob) => {
+              if (!blob) return reject(new Error(`Could not process "${file.name}"`));
+              const base = (file.name || "image").replace(/\.[^.]+$/, "");
+              resolve(new File([blob], `${base}.jpg`, { type: "image/jpeg" }));
+            },
+            "image/jpeg",
+            0.85
+          );
+        } catch (err) {
+          reject(new Error(`Could not process "${file.name}": ${err.message}`));
+        }
+      };
+      img.onerror = () => reject(new Error(`Could not decode "${file.name}" (HEIC not supported — use JPG/PNG).`));
+      img.src = e.target.result;
+    };
+    reader.onerror = () => reject(new Error(`Could not read "${file.name}".`));
+    reader.readAsDataURL(file);
+  });
+}
+
+function ReturnsInput() {
+  const navigate = useNavigate();
+  const [toast, setToast] = useState(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [tracking, setTracking] = useState("");
+  const [receivedDate, setReceivedDate] = useState("");
+  const [remark, setRemark] = useState("");
+  const [quantity, setQuantity] = useState(1);
+  const [labelFiles, setLabelFiles] = useState([]);
+  const [units, setUnits] = useState([{ laptop: "", files: [] }]);
+
+  useEffect(() => {
+    const today = new Date().toISOString().slice(0, 10);
+    setReceivedDate(today);
+  }, []);
+
+  // Keep the units array length in sync with quantity, preserving entered data.
+  useEffect(() => {
+    const qty = Math.max(1, parseInt(quantity, 10) || 1);
+    setUnits((prev) => {
+      const next = prev.slice(0, qty);
+      while (next.length < qty) next.push({ laptop: "", files: [] });
+      return next;
+    });
+  }, [quantity]);
+
+  const setUnitLaptop = (i, val) =>
+    setUnits((prev) => prev.map((u, idx) => (idx === i ? { ...u, laptop: val } : u)));
+  const setUnitFiles = (i, files) =>
+    setUnits((prev) => prev.map((u, idx) => (idx === i ? { ...u, files: Array.from(files) } : u)));
+
+  const removeLabelFile = (i) =>
+    setLabelFiles((prev) => prev.filter((_, idx) => idx !== i));
+  const removeUnitFile = (i, fi) =>
+    setUnits((prev) =>
+      prev.map((u, idx) => (idx === i ? { ...u, files: u.files.filter((_, fidx) => fidx !== fi) } : u))
+    );
+
+  const applyNameToAllUnits = () =>
+    setUnits((prev) => prev.map((u) => ({ ...u, laptop: prev[0].laptop })));
+
+  const qty = Math.max(1, parseInt(quantity, 10) || 1);
+
+  // Barcode scanners send Enter after the code; keep that from submitting a
+  // half-filled form. Submit happens only via the Submit button.
+  const preventEnterSubmit = (e) => {
+    if (e.key === "Enter" && e.target.tagName === "INPUT") e.preventDefault();
+  };
+
+  const handleSubmit = async (e) => {
+    e.preventDefault();
+    if (!tracking.trim()) return setToast({ message: "Tracking number is required.", type: "error" });
+    if (labelFiles.length === 0) return setToast({ message: "Please add at least one shipping label image.", type: "error" });
+    for (let i = 0; i < units.length; i++) {
+      if (!units[i].laptop.trim()) return setToast({ message: `Please enter a laptop name for Unit ${i + 1}.`, type: "error" });
+    }
+
+    setSubmitting(true);
+    setToast({ message: "Processing images & uploading…", type: "success" });
+    try {
+      const data = new FormData();
+      data.append("tracking", tracking.trim());
+      data.append("receivedDate", receivedDate);
+      data.append("quantity", String(qty));
+      data.append("remark", remark.trim());
+
+      const labels = await Promise.all(labelFiles.map(resizeImage));
+      labels.forEach((f) => data.append("images", f));
+
+      for (let i = 0; i < units.length; i++) {
+        data.append(`unit_laptop_${i}`, units[i].laptop.trim());
+        const imgs = await Promise.all(units[i].files.map(resizeImage));
+        imgs.forEach((f) => data.append(`unit_images_${i}`, f));
+      }
+
+      const res = await fetch(`${API}/returns/submit`, { method: "POST", body: data });
+      const result = await res.json();
+      if (res.ok && result.status === "success") {
+        const ids = result.fileNos || [result.fileNo];
+        setToast({ message: "✔️ Saved! Assigned: " + ids.join(", "), type: "success" });
+        setTimeout(() => navigate("/returns"), 900);
+      } else {
+        setToast({ message: "Error: " + (result.message || "Unknown error"), type: "error" });
+        setSubmitting(false);
+      }
+    } catch (err) {
+      setToast({ message: "Submission failed: " + (err.message || err), type: "error" });
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <>
+      {toast && <Toast {...toast} onClose={() => setToast(null)} />}
+      <div className="w-full bg-white rounded-lg shadow p-6 max-w-xl mx-auto mt-4">
+        <h1 className="text-2xl font-bold mb-4 text-center">Input New Returns Item</h1>
+        <button
+          onClick={() => navigate("/returns")}
+          className="mb-4 bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600"
+        >
+          Back
+        </button>
+
+        <form onSubmit={handleSubmit} onKeyDown={preventEnterSubmit}>
+          <div className="mb-4">
+            <label className="block text-gray-700 font-bold mb-2">Tracking Number<span className="text-red-600">*</span></label>
+            <input type="text" value={tracking} onChange={(e) => setTracking(e.target.value)} placeholder="Scan or type tracking #" autoFocus className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600" required />
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-gray-700 font-bold mb-2">Received Date<span className="text-red-600">*</span></label>
+            <input type="date" value={receivedDate} max={new Date().toISOString().slice(0, 10)} onChange={(e) => setReceivedDate(e.target.value)} className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600" required />
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-gray-700 font-bold mb-2">Quantity<span className="text-red-600">*</span></label>
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setQuantity((q) => Math.max(1, (parseInt(q, 10) || 1) - 1))}
+                disabled={qty <= 1}
+                className="bg-gray-200 w-12 py-2 rounded text-lg font-bold hover:bg-gray-300 disabled:opacity-40"
+                aria-label="Decrease quantity"
+              >
+                −
+              </button>
+              <input type="number" min="1" step="1" value={quantity} onChange={(e) => setQuantity(e.target.value)} className="w-24 text-center p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600" required />
+              <button
+                type="button"
+                onClick={() => setQuantity((q) => Math.max(1, (parseInt(q, 10) || 1) + 1))}
+                className="bg-gray-200 w-12 py-2 rounded text-lg font-bold hover:bg-gray-300"
+                aria-label="Increase quantity"
+              >
+                +
+              </button>
+            </div>
+            <div className="text-xs text-gray-500 mt-1">
+              {qty === 1 ? "Will create 1 row with a new File No." : `Will create ${qty} rows, each with its own File No and laptop details.`}
+            </div>
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-gray-700 font-bold mb-2">Remark</label>
+            <textarea value={remark} onChange={(e) => setRemark(e.target.value)} placeholder="Optional notes about the shipment as a whole…" className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600 h-24" />
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-gray-700 font-bold mb-2">Shipping Label Images<span className="text-red-600">*</span></label>
+            <div className="text-xs text-gray-500 mb-2">Shared across all units in this submission. Auto-resized before upload.</div>
+            <input type="file" accept="image/*" multiple onChange={(e) => setLabelFiles(Array.from(e.target.files))} className="w-full p-2 border rounded" />
+            {labelFiles.length > 0 && (
+              <>
+                <div className="text-xs text-gray-500 mt-1">{labelFiles.length} file(s) selected</div>
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {labelFiles.map((file, i) => (
+                    <div key={i} className="relative w-24 h-24 rounded overflow-hidden group">
+                      <img src={URL.createObjectURL(file)} alt="Preview" className="w-full h-full object-cover rounded" />
+                      <button
+                        type="button"
+                        onClick={() => removeLabelFile(i)}
+                        className="absolute top-1 right-1 bg-red-600 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center hover:bg-red-700 shadow-md"
+                        title="Remove image"
+                      >
+                        ✕
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </>
+            )}
+          </div>
+
+          <div className="mb-4">
+            <label className="block text-gray-700 font-bold mb-2">Unit Details<span className="text-red-600">*</span></label>
+            <div className="text-xs text-gray-500 mb-2">Laptop name and (optional) per-unit photos.</div>
+            <div className="flex flex-col gap-4">
+              {units.map((u, i) => (
+                <div key={i} className="border rounded-lg p-4 bg-gray-50">
+                  <div className="flex items-center justify-between mb-2">
+                    <span className="font-bold text-gray-700">{qty > 1 ? `Unit ${i + 1} of ${qty}` : "Unit Details"}</span>
+                    {qty > 1 && <span className="font-mono text-xs font-semibold bg-purple-100 text-purple-800 px-2 py-0.5 rounded-full">File No auto-assigned</span>}
+                  </div>
+                  <label className="block text-gray-700 font-bold mb-2">Laptop Name<span className="text-red-600">*</span></label>
+                  <input type="text" value={u.laptop} onChange={(e) => setUnitLaptop(i, e.target.value)} placeholder="e.g., Dell Latitude 7420" className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600" required />
+                  {i === 0 && qty > 1 && u.laptop.trim() && (
+                    <button
+                      type="button"
+                      onClick={applyNameToAllUnits}
+                      className="mt-2 text-blue-500 text-sm font-semibold hover:underline"
+                    >
+                      ↓ Apply this name to all {qty} units
+                    </button>
+                  )}
+                  <label className="block text-gray-700 font-bold mb-2 mt-4">Photos of this unit</label>
+                  <div className="text-xs text-gray-500 mb-1">Optional. e.g. damage, condition, serial sticker.</div>
+                  <input type="file" accept="image/*" multiple onChange={(e) => setUnitFiles(i, e.target.files)} className="w-full p-2 border rounded" />
+                  {u.files.length > 0 && (
+                    <>
+                      <div className="text-xs text-gray-500 mt-1">{u.files.length} file(s) selected</div>
+                      <div className="mt-2 flex flex-wrap gap-2">
+                        {u.files.map((file, fi) => (
+                          <div key={fi} className="relative w-24 h-24 rounded overflow-hidden group">
+                            <img src={URL.createObjectURL(file)} alt="Preview" className="w-full h-full object-cover rounded" />
+                            <button
+                              type="button"
+                              onClick={() => removeUnitFile(i, fi)}
+                              className="absolute top-1 right-1 bg-red-600 text-white text-xs rounded-full w-6 h-6 flex items-center justify-center hover:bg-red-700 shadow-md"
+                              title="Remove image"
+                            >
+                              ✕
+                            </button>
+                          </div>
+                        ))}
+                      </div>
+                    </>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <button type="submit" disabled={submitting} className="w-full sm:w-auto bg-blue-600 text-white px-4 py-2 rounded hover:bg-blue-700 disabled:opacity-50">
+            {submitting ? "Submitting..." : "Submit"}
+          </button>
+        </form>
+      </div>
+    </>
+  );
+}
+
+export default ReturnsInput;

--- a/frontend/src/components/Returns/ReturnsList.js
+++ b/frontend/src/components/Returns/ReturnsList.js
@@ -1,0 +1,570 @@
+import React, { useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import { ClipLoader } from "react-spinners";
+import copy from "copy-to-clipboard";
+
+const API = `http://${window.location.hostname}:8088`;
+const PAGE_SIZE = 20;
+
+function formatTimestamp(ts) {
+  if (!ts) return "";
+  const d = new Date(ts);
+  if (isNaN(d.getTime())) return String(ts);
+  return d.toLocaleString();
+}
+
+function unitStatus(item) {
+  if (item.shipDate) return "Shipped";
+  if (item.inspectionDate) return "Inspected";
+  return "Pending";
+}
+
+function itemHaystack(item) {
+  let statusWords;
+  if (item.shipDate) statusWords = " done inspected shipped ";
+  else if (item.inspectionDate) statusWords = " done inspected ";
+  else statusWords = " pending ";
+  return (
+    " " + [item.id, item.fileNo, item.tracking, item.laptop, item.serials,
+      item.pallet, item.bulkType, item.receivedDate, item.inspectionDate,
+      item.shipDate, item.shipBatch].map((v) => v || "").join(" ") +
+    statusWords
+  ).toLowerCase();
+}
+
+// Collapse rows into tracking-number groups, preserving newest-first order.
+function groupByTracking(items) {
+  const groups = [];
+  const byTracking = {};
+  items.forEach((it) => {
+    const key = (it.tracking || "").trim();
+    if (!key) {
+      groups.push({ tracking: "", units: [it] });
+      return;
+    }
+    if (byTracking[key]) byTracking[key].units.push(it);
+    else {
+      const g = { tracking: key, units: [it] };
+      byTracking[key] = g;
+      groups.push(g);
+    }
+  });
+  return groups;
+}
+
+const COLUMNS = [
+  { key: "fileNo", label: "File No" },
+  { key: "tracking", label: "Tracking #" },
+  { key: "laptop", label: "Laptop Name" },
+  { key: "serials", label: "Serial #" },
+  { key: "receivedDate", label: "Received Date" },
+  { key: "pallet", label: "Pallet" },
+  { key: "bulkType", label: "Bulk Type" },
+  { key: "status", label: "Status" },
+  { key: "timestamp", label: "Submitted" },
+];
+
+const STATUS_CLASS = {
+  Pending: "bg-yellow-100 text-yellow-800",
+  Inspected: "bg-green-100 text-green-800",
+  Shipped: "bg-purple-100 text-purple-800",
+};
+
+function StatusBadge({ status }) {
+  return (
+    <span className={`inline-block text-xs font-semibold px-2 py-0.5 rounded ${STATUS_CLASS[status]}`}>
+      {status}
+    </span>
+  );
+}
+
+function ReturnsList() {
+  const navigate = useNavigate();
+  const [items, setItems] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [search, setSearch] = useState("");
+  const [statusFilter, setStatusFilter] = useState("");
+  const [palletFilter, setPalletFilter] = useState("");
+  const [bulkFilter, setBulkFilter] = useState("");
+  const [combine, setCombine] = useState(true);
+  const [page, setPage] = useState(1);
+  const [sortConfig, setSortConfig] = useState({ key: null, direction: "asc" });
+  const [expandedGroups, setExpandedGroups] = useState({});
+  const [toast, setToast] = useState({ message: "", visible: false });
+  const [visibleColumns, setVisibleColumns] = useState(() => {
+    const saved = {};
+    COLUMNS.forEach((col) => {
+      const savedState = localStorage.getItem(`/returns-${col.key}`);
+      saved[col.key] = savedState !== null ? JSON.parse(savedState) : true;
+    });
+    return saved;
+  });
+  const [showColumnFilter, setShowColumnFilter] = useState(false);
+
+  const loadData = () => {
+    setLoading(true);
+    setError("");
+    fetch(`${API}/returns/list`)
+      .then((res) => res.json())
+      .then((data) => {
+        if (data.status === "success") {
+          setItems(
+            (data.items || []).map((it) => ({ ...it, _hay: itemHaystack(it) }))
+          );
+        } else {
+          setError(data.message || "Load failed");
+        }
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(String(err));
+        setLoading(false);
+      });
+  };
+
+  useEffect(loadData, []);
+
+  const pallets = useMemo(() => {
+    const set = new Set();
+    items.forEach((it) => {
+      const p = (it.pallet || "").trim();
+      if (p) set.add(p);
+    });
+    return Array.from(set).sort((a, b) =>
+      a.localeCompare(b, undefined, { numeric: true })
+    );
+  }, [items]);
+
+  const filtered = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return items.filter((item) => {
+      if (statusFilter === "pending" && item.inspectionDate) return false;
+      if (statusFilter === "done" && (!item.inspectionDate || item.shipDate)) return false;
+      if (statusFilter === "shipped" && !item.shipDate) return false;
+      if (palletFilter && item.pallet !== palletFilter) return false;
+      if (bulkFilter) {
+        const b = (item.bulkType || "").trim();
+        if (bulkFilter === "__none__") {
+          if (b) return false;
+        } else if (b !== bulkFilter) return false;
+      }
+      if (q && item._hay.indexOf(q) === -1) return false;
+      return true;
+    });
+  }, [items, search, statusFilter, palletFilter, bulkFilter]);
+
+  const sorted = useMemo(() => {
+    if (!sortConfig.key) return filtered;
+    const collator = new Intl.Collator(undefined, {
+      numeric: true,
+      sensitivity: "base",
+    });
+    const value = (item) =>
+      (sortConfig.key === "status" ? unitStatus(item) : item[sortConfig.key])
+        ?.toString()
+        .trim() ?? "";
+    return [...filtered].sort((a, b) =>
+      sortConfig.direction === "asc"
+        ? collator.compare(value(a), value(b))
+        : collator.compare(value(b), value(a))
+    );
+  }, [filtered, sortConfig]);
+
+  const groups = useMemo(
+    () => (combine ? groupByTracking(sorted) : sorted.map((it) => ({ tracking: (it.tracking || "").trim(), units: [it] }))),
+    [sorted, combine]
+  );
+
+  const totalPages = Math.max(1, Math.ceil(groups.length / PAGE_SIZE));
+  const currentPage = Math.min(page, totalPages);
+  const pageGroups = groups.slice((currentPage - 1) * PAGE_SIZE, currentPage * PAGE_SIZE);
+
+  useEffect(() => setPage(1), [search, statusFilter, palletFilter, bulkFilter, combine, sortConfig]);
+
+  const handleReset = () => {
+    setSearch("");
+    setStatusFilter("");
+    setPalletFilter("");
+    setBulkFilter("");
+  };
+
+  const toggleGroup = (key) => {
+    setExpandedGroups((prev) => ({ ...prev, [key]: !prev[key] }));
+  };
+
+  const handleSort = (key) => {
+    setSortConfig((prev) => {
+      if (prev.key === key) {
+        return { key, direction: prev.direction === "asc" ? "desc" : "asc" };
+      }
+      return { key, direction: "asc" };
+    });
+  };
+
+  const toggleColumn = (column) => {
+    setVisibleColumns((prev) => {
+      const next = { ...prev, [column]: !prev[column] };
+      localStorage.setItem(`/returns-${column}`, JSON.stringify(next[column]));
+      return next;
+    });
+  };
+
+  const openDetail = (id) =>
+    window.open(
+      `http://${window.location.hostname}:${window.location.port}/returns/${encodeURIComponent(id)}`,
+      "_blank"
+    );
+
+  const handleCopy = (text, e) => {
+    e.stopPropagation();
+    let copied = false;
+    try {
+      copied = copy(text);
+    } catch {
+      copied = false;
+    }
+    setToast({ message: copied ? `Copied: ${text}` : "Copy not available", visible: true });
+    setTimeout(() => setToast({ message: "", visible: false }), 2000);
+  };
+
+  const copyableColumns = ["fileNo", "tracking", "serials"];
+
+  const cellValue = (item, colKey) => {
+    switch (colKey) {
+      case "status":
+        return <StatusBadge status={unitStatus(item)} />;
+      case "timestamp":
+        return formatTimestamp(item.timestamp);
+      case "laptop":
+        return (
+          <span className="line-clamp-2 max-w-md" title={item.laptop}>
+            {item.laptop}
+          </span>
+        );
+      default:
+        return item[colKey];
+    }
+  };
+
+  const cellClass = (colKey) =>
+    `p-2 border ${copyableColumns.includes(colKey) ? "cursor-pointer hover:bg-gray-200" : ""}`;
+
+  const cellCopyHandler = (item, colKey) => (e) => {
+    if (copyableColumns.includes(colKey) && item[colKey]) {
+      handleCopy(item[colKey], e);
+    }
+  };
+
+  const renderGroupRow = (g, groupKey) => {
+    const first = g.units[0];
+    const hiddenRowCount = g.units.length - 1;
+    let pending = 0, inspected = 0, shipped = 0;
+    g.units.forEach((u) => {
+      if (u.shipDate) shipped++;
+      else if (u.inspectionDate) inspected++;
+      else pending++;
+    });
+
+    const isMulti = hiddenRowCount > 0;
+    const isExpanded = isMulti && expandedGroups[groupKey];
+
+    return (
+      <React.Fragment key={groupKey}>
+        <tr
+          className={`cursor-pointer ${isMulti ? "bg-gray-100 font-bold" : "hover:bg-gray-100"}`}
+          onClick={() => openDetail(first.id)}
+        >
+          <td className={`p-2 border text-center ${isExpanded ? "border-l-4 border-l-purple-400" : ""}`}>
+            {isMulti && (
+              <button
+                onClick={(e) => {
+                  e.stopPropagation();
+                  toggleGroup(groupKey);
+                }}
+                title={isExpanded ? "Collapse group" : `Show ${hiddenRowCount} more unit${hiddenRowCount === 1 ? "" : "s"}`}
+                className="text-lg font-bold whitespace-nowrap"
+              >
+                {isExpanded ? "➖" : `➕ ${hiddenRowCount}`}
+              </button>
+            )}
+          </td>
+          {COLUMNS.map(
+            (col) =>
+              visibleColumns[col.key] && (
+                <td key={col.key} className={cellClass(col.key)} onClick={cellCopyHandler(first, col.key)}>
+                  {col.key === "tracking" && isMulti ? (
+                    <>
+                      {cellValue(first, col.key)}
+                      <span className="ml-2 inline-block text-xs font-semibold px-2 py-0.5 rounded bg-purple-100 text-purple-800 align-middle whitespace-nowrap">
+                        {g.units.length} units
+                      </span>
+                    </>
+                  ) : col.key === "status" && isMulti ? (
+                    <span className="text-xs font-semibold space-x-1">
+                      {pending > 0 && <span className="text-yellow-700">{pending} pending</span>}
+                      {inspected > 0 && <span className="text-green-700">{inspected} inspected</span>}
+                      {shipped > 0 && <span className="text-purple-700">{shipped} shipped</span>}
+                    </span>
+                  ) : (
+                    cellValue(first, col.key)
+                  )}
+                </td>
+              )
+          )}
+        </tr>
+        {isExpanded &&
+          g.units.slice(1).map((item, idx) => (
+            <tr
+              key={item.id}
+              className="bg-purple-50 hover:bg-purple-100 cursor-pointer"
+              onClick={() => openDetail(item.id)}
+            >
+              <td className="p-2 border border-l-4 border-l-purple-400 text-center text-purple-400 font-bold">↳</td>
+              {COLUMNS.map(
+                (col) =>
+                  visibleColumns[col.key] && (
+                    <td
+                      key={col.key}
+                      className={col.key === "tracking" ? "p-2 border" : cellClass(col.key)}
+                      onClick={col.key === "tracking" ? undefined : cellCopyHandler(item, col.key)}
+                    >
+                      {col.key === "tracking" ? (
+                        <span className="text-xs text-gray-400 whitespace-nowrap">
+                          unit {item.unitIndex || idx + 2}
+                          {item.groupSize ? ` of ${item.groupSize}` : ""}
+                        </span>
+                      ) : (
+                        cellValue(item, col.key)
+                      )}
+                    </td>
+                  )
+              )}
+            </tr>
+          ))}
+      </React.Fragment>
+    );
+  };
+
+  return (
+    <div className="p-6">
+      <div className="sticky top-0 z-50 bg-gray-100">
+        <h1 className="text-2xl font-bold mb-4">Returns List</h1>
+        <div className="flex space-x-2 mb-4">
+          <Link to="/returns/input">
+            <button className="bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">
+              Input
+            </button>
+          </Link>
+          <button
+            onClick={() => navigate("/dashboard")}
+            className="bg-orange-500 text-white px-4 py-2 rounded hover:bg-orange-600"
+          >
+            Home
+          </button>
+          <button
+            onClick={() => navigate("/returns/ship")}
+            className="bg-purple-500 text-white px-4 py-2 rounded hover:bg-purple-600"
+          >
+            Ship Out
+          </button>
+          <button
+            onClick={() => navigate("/returns/report")}
+            className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+          >
+            Report
+          </button>
+          <button
+            onClick={loadData}
+            className="bg-gray-200 text-gray-800 px-4 py-2 rounded hover:bg-gray-300"
+          >
+            Refresh
+          </button>
+        </div>
+
+        <div className="bg-white p-4 rounded-lg shadow mb-4">
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-4">
+            <div>
+              <label className="block text-gray-700 font-bold mb-2">Search</label>
+              <input
+                type="text"
+                value={search}
+                onChange={(e) => setSearch(e.target.value)}
+                placeholder="File No, tracking, laptop, serial, pallet, ship batch…"
+                className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
+              />
+            </div>
+          </div>
+          <div className="flex flex-wrap gap-4 items-center justify-between">
+            <div className="flex flex-wrap gap-4">
+              <div>
+                <label className="block text-gray-700 font-bold mb-2">Status</label>
+                <select
+                  value={statusFilter}
+                  onChange={(e) => setStatusFilter(e.target.value)}
+                  className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
+                >
+                  <option value="">All Statuses</option>
+                  <option value="pending">Pending inspection</option>
+                  <option value="done">Inspected, not shipped</option>
+                  <option value="shipped">Shipped</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-gray-700 font-bold mb-2">Pallet</label>
+                <select
+                  value={palletFilter}
+                  onChange={(e) => setPalletFilter(e.target.value)}
+                  className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
+                >
+                  <option value="">All Pallets</option>
+                  {pallets.map((p) => (
+                    <option key={p} value={p}>{p}</option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <label className="block text-gray-700 font-bold mb-2">Bulk Type</label>
+                <select
+                  value={bulkFilter}
+                  onChange={(e) => setBulkFilter(e.target.value)}
+                  className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
+                >
+                  <option value="">All Bulk Types</option>
+                  <option value="New Bulk">New Bulk</option>
+                  <option value="Old Bulk">Old Bulk</option>
+                  <option value="__none__">Not set</option>
+                </select>
+              </div>
+              <div>
+                <label className="block text-gray-700 font-bold mb-2">View</label>
+                <select
+                  value={combine ? "combined" : "expanded"}
+                  onChange={(e) => setCombine(e.target.value === "combined")}
+                  className="w-full p-2 border rounded focus:outline-none focus:ring-2 focus:ring-blue-600"
+                >
+                  <option value="combined">Combine by tracking</option>
+                  <option value="expanded">Show every unit</option>
+                </select>
+              </div>
+            </div>
+            <div className="flex items-center h-full">
+              <button
+                type="button"
+                onClick={handleReset}
+                className="bg-red-600 hover:bg-red-700 m-2 text-white font-semibold px-6 py-2 rounded shadow"
+              >
+                Reset
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div className="flex justify-between items-center mb-4">
+          <div className="flex space-x-4">
+            <span>
+              Total Count: {filtered.length}
+              {groups.length !== filtered.length && (
+                <> ({groups.length} tracking group{groups.length === 1 ? "" : "s"})</>
+              )}
+            </span>
+          </div>
+          <div className="relative">
+            <button
+              onClick={() => setShowColumnFilter(!showColumnFilter)}
+              className="bg-gray-200 px-4 py-2 rounded"
+            >
+              Filter Columns ▼
+            </button>
+            {showColumnFilter && (
+              <div className="absolute right-0 mt-2 bg-white p-4 rounded shadow-lg z-10 min-w-[200px] max-w-[250px]">
+                {COLUMNS.map((col) => (
+                  <label key={col.key} className="block">
+                    <input
+                      type="checkbox"
+                      checked={visibleColumns[col.key]}
+                      onChange={() => toggleColumn(col.key)}
+                      className="mr-2"
+                    />
+                    {col.label}
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {loading ? (
+        <div className="p-12 flex justify-center">
+          <ClipLoader color="#4B5563" size={40} />
+        </div>
+      ) : error ? (
+        <div className="bg-red-100 text-red-800 p-6 rounded-lg text-center">{error}</div>
+      ) : pageGroups.length === 0 ? (
+        <p className="text-gray-500">No matching returns.</p>
+      ) : (
+        <>
+          <div className="overflow-x-auto">
+            <table className="w-full border-collapse bg-white shadow rounded">
+              <thead>
+                <tr className="bg-gray-200 sticky z-40">
+                  <th className="p-2 border"></th>
+                  {COLUMNS.map(
+                    (col) =>
+                      visibleColumns[col.key] && (
+                        <th
+                          key={col.key}
+                          className="p-2 border cursor-pointer hover:bg-blue-100"
+                          onClick={() => handleSort(col.key)}
+                        >
+                          {col.label}
+                          {sortConfig.key === col.key && (
+                            <span>{sortConfig.direction === "asc" ? " ▲" : " ▼"}</span>
+                          )}
+                        </th>
+                      )
+                  )}
+                </tr>
+              </thead>
+              <tbody>
+                {pageGroups.map((g, i) =>
+                  renderGroupRow(g, g.tracking || `row-${(currentPage - 1) * PAGE_SIZE + i}`)
+                )}
+              </tbody>
+            </table>
+          </div>
+          {totalPages > 1 && (
+            <div className="flex items-center justify-center gap-2 mt-4 flex-wrap">
+              <button
+                disabled={currentPage === 1}
+                onClick={() => setPage(currentPage - 1)}
+                className="px-3 py-1.5 border border-gray-300 rounded text-sm font-semibold bg-white disabled:opacity-40"
+              >
+                ‹ Prev
+              </button>
+              <span className="text-sm text-gray-600">
+                Page {currentPage} of {totalPages}
+              </span>
+              <button
+                disabled={currentPage === totalPages}
+                onClick={() => setPage(currentPage + 1)}
+                className="px-3 py-1.5 border border-gray-300 rounded text-sm font-semibold bg-white disabled:opacity-40"
+              >
+                Next ›
+              </button>
+            </div>
+          )}
+        </>
+      )}
+
+      {toast.visible && (
+        <div className="fixed bottom-4 right-4 bg-gray-800 text-white px-4 py-2 rounded shadow-lg z-50">
+          {toast.message}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default ReturnsList;

--- a/frontend/src/components/Returns/ReturnsReport.js
+++ b/frontend/src/components/Returns/ReturnsReport.js
@@ -1,0 +1,147 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ClipLoader } from "react-spinners";
+
+const API = `http://${window.location.hostname}:8088`;
+
+function formatMonth(ym) {
+  const parts = (ym || "").split("-");
+  if (parts.length !== 2) return ym;
+  const d = new Date(parseInt(parts[0], 10), parseInt(parts[1], 10) - 1, 1);
+  if (isNaN(d.getTime())) return ym;
+  return d.toLocaleString(undefined, { month: "long", year: "numeric" });
+}
+
+function ReturnsReport() {
+  const navigate = useNavigate();
+  const [data, setData] = useState(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState("");
+
+  useEffect(() => {
+    fetch(`${API}/returns/report`)
+      .then((r) => r.json())
+      .then((res) => {
+        if (res.status === "success") setData(res);
+        else setError(res.message || "Could not load report.");
+        setLoading(false);
+      })
+      .catch((err) => { setError(String(err)); setLoading(false); });
+  }, []);
+
+  const exportCsv = () => {
+    if (!data || !data.months) return;
+    const rows = [["Month", "Received", "Inspected", "Shipped"]];
+    data.months.forEach((m) => rows.push([m.month, m.received, m.inspected, m.shipped]));
+    if (data.totals) rows.push(["TOTAL", data.totals.received, data.totals.inspected, data.totals.shipped]);
+    const csv = rows.map((r) => r.map((c) => {
+      const s = String(c);
+      return s.includes(",") || s.includes('"') ? `"${s.replace(/"/g, '""')}"` : s;
+    }).join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv;charset=utf-8" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `returns-monthly-report_${new Date().toISOString().slice(0, 10)}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  };
+
+  const months = (data && data.months) || [];
+  const totals = (data && data.totals) || { received: 0, inspected: 0, shipped: 0 };
+  const maxVal = Math.max(1, ...months.flatMap((m) => [m.received, m.inspected, m.shipped]));
+
+  const card = "bg-white rounded-lg shadow-sm p-6 mb-4";
+
+  return (
+    <div className="max-w-3xl mx-auto p-5">
+      <h1 className="text-2xl font-bold mb-4">Monthly Report</h1>
+      <div className="flex space-x-2 mb-4">
+        <button
+          onClick={() => navigate("/returns")}
+          className="bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600"
+        >
+          Back
+        </button>
+        <button
+          onClick={exportCsv}
+          className="bg-green-600 text-white px-4 py-2 rounded hover:bg-green-700"
+        >
+          Export CSV
+        </button>
+        <button
+          onClick={() => window.print()}
+          className="bg-purple-500 text-white px-4 py-2 rounded hover:bg-purple-600"
+        >
+          🖨️ Print
+        </button>
+      </div>
+
+      {loading ? (
+        <div className="p-12 flex justify-center"><ClipLoader color="#6366f1" size={36} /></div>
+      ) : error ? (
+        <div className="bg-red-100 text-red-800 p-5 rounded-lg text-center">{error}</div>
+      ) : months.length === 0 ? (
+        <div className={`${card} text-center text-gray-500`}>No data yet.</div>
+      ) : (
+        <>
+          <div className={card}>
+            <h2 className="text-base font-bold mb-3.5">All-time totals</h2>
+            <div className="grid grid-cols-3 gap-3">
+              {[
+                { label: "Received", num: totals.received, bg: "bg-blue-50", color: "text-blue-700" },
+                { label: "Inspected", num: totals.inspected, bg: "bg-green-50", color: "text-emerald-700" },
+                { label: "Shipped", num: totals.shipped, bg: "bg-purple-50", color: "text-purple-700" },
+              ].map((t) => (
+                <div key={t.label} className={`${t.bg} p-4 rounded-lg text-center`}>
+                  <div className="text-xs font-bold uppercase tracking-wide text-gray-500">{t.label}</div>
+                  <div className={`text-3xl font-bold mt-1.5 ${t.color}`}>{t.num}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div className={card}>
+            <h2 className="text-base font-bold mb-3.5">Monthly breakdown</h2>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm border-collapse">
+                <thead>
+                  <tr className="bg-gray-50 text-gray-500 text-xs uppercase tracking-wide">
+                    <th className="text-left p-2.5 border-b border-gray-200">Month</th>
+                    <th className="text-right p-2.5 border-b border-gray-200">Received</th>
+                    <th className="text-right p-2.5 border-b border-gray-200">Inspected</th>
+                    <th className="text-right p-2.5 border-b border-gray-200">Shipped</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {months.map((m) => (
+                    <tr key={m.month}>
+                      <td className="p-2.5 border-b border-gray-100">
+                        <div className="font-bold text-gray-800">{formatMonth(m.month)}</div>
+                        <div className="text-xs text-gray-400">{m.month}</div>
+                      </td>
+                      {[["received", "bg-blue-500"], ["inspected", "bg-emerald-500"], ["shipped", "bg-purple-500"]].map(([k, bar]) => (
+                        <td key={k} className="p-2.5 border-b border-gray-100 text-right tabular-nums">
+                          <div>{m[k]}</div>
+                          {m[k] > 0 && (
+                            <div className="h-1.5 rounded bg-gray-200 mt-1 ml-auto w-24 overflow-hidden">
+                              <div className={`h-full rounded ${bar}`} style={{ width: `${Math.max(2, Math.round((m[k] / maxVal) * 100))}%` }} />
+                            </div>
+                          )}
+                        </td>
+                      ))}
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default ReturnsReport;

--- a/frontend/src/components/Returns/ReturnsShipOut.js
+++ b/frontend/src/components/Returns/ReturnsShipOut.js
@@ -1,0 +1,178 @@
+import React, { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import Toast from "../common/Toast";
+
+const API = `http://${window.location.hostname}:8088`;
+
+function ReturnsShipOut() {
+  const navigate = useNavigate();
+  const [toast, setToast] = useState(null);
+  const [pallets, setPallets] = useState([]);
+  const [currentPallet, setCurrentPallet] = useState(null);
+  const [units, setUnits] = useState([]);
+  const [selected, setSelected] = useState({}); // id -> bool
+  const [shipDate, setShipDate] = useState("");
+  const [loadingUnits, setLoadingUnits] = useState(false);
+  const [shipping, setShipping] = useState(false);
+
+  useEffect(() => setShipDate(new Date().toISOString().slice(0, 10)), []);
+
+  const loadPallets = (reselect) => {
+    fetch(`${API}/returns/pallets`)
+      .then((r) => r.json())
+      .then((res) => {
+        if (res.status === "success") {
+          setPallets(res.pallets || []);
+          if (reselect) {
+            const still = (res.pallets || []).some((p) => p.pallet === reselect && p.ready > 0);
+            if (still) selectPallet(reselect);
+            else { setCurrentPallet(null); setUnits([]); }
+          }
+        } else setToast({ message: res.message || "Could not load pallets", type: "error" });
+      })
+      .catch((err) => setToast({ message: "Could not load pallets: " + err, type: "error" }));
+  };
+
+  useEffect(() => loadPallets(null), []);
+
+  const selectPallet = (pallet) => {
+    setCurrentPallet(pallet);
+    setLoadingUnits(true);
+    fetch(`${API}/returns/pallets/${encodeURIComponent(pallet)}/units`)
+      .then((r) => r.json())
+      .then((res) => {
+        setLoadingUnits(false);
+        if (res.status === "success") {
+          const list = res.units || [];
+          setUnits(list);
+          const sel = {};
+          list.forEach((u) => { if (!u.shipDate && u.inspectionDate) sel[u.id] = true; });
+          setSelected(sel);
+        } else setToast({ message: res.message || "Could not load units", type: "error" });
+      })
+      .catch((err) => { setLoadingUnits(false); setToast({ message: "Could not load units: " + err, type: "error" }); });
+  };
+
+  const readyIds = units.filter((u) => u.inspectionDate && !u.shipDate).map((u) => u.id);
+  const selectedIds = Object.keys(selected).filter((id) => selected[id] && readyIds.includes(id));
+
+  const toggle = (id) => setSelected((prev) => ({ ...prev, [id]: !prev[id] }));
+  const selectAll = () => { const s = {}; readyIds.forEach((id) => (s[id] = true)); setSelected(s); };
+  const selectNone = () => setSelected({});
+
+  const ship = () => {
+    if (!selectedIds.length) return setToast({ message: "No units selected.", type: "error" });
+    if (!shipDate) return setToast({ message: "Ship date is required.", type: "error" });
+    setShipping(true);
+    const isWholePallet = selectedIds.length === readyIds.length;
+    fetch(`${API}/returns/ship`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ shipDate, unitIds: selectedIds, ...(isWholePallet ? { pallet: currentPallet } : {}) }),
+    })
+      .then((r) => r.json())
+      .then((res) => {
+        setShipping(false);
+        if (res.status === "success") {
+          let msg = `✓ Shipped ${res.shippedCount} unit(s) under batch ${res.batchId}.`;
+          if (res.skipped && res.skipped.length) msg += ` Skipped ${res.skipped.length}.`;
+          setToast({ message: msg, type: "success" });
+          loadPallets(currentPallet);
+        } else setToast({ message: "Error: " + (res.message || "Unknown error"), type: "error" });
+      })
+      .catch((err) => { setShipping(false); setToast({ message: "Ship failed: " + err, type: "error" }); });
+  };
+
+  const card = "bg-white rounded-lg shadow-sm p-6 mb-4";
+
+  return (
+    <>
+      {toast && <Toast {...toast} onClose={() => setToast(null)} />}
+      <div className="max-w-3xl mx-auto p-5">
+        <h1 className="text-2xl font-bold mb-4">Ship Out</h1>
+        <button
+          onClick={() => navigate("/returns")}
+          className="mb-4 bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600"
+        >
+          Back
+        </button>
+
+        <div className={card}>
+          <h2 className="text-base font-bold mb-2">1. Select a pallet</h2>
+          <div className="text-xs text-gray-500 mb-3">Ready = inspected but not shipped.</div>
+          {pallets.length === 0 ? (
+            <div className="text-center text-gray-500 py-5">No pallets yet. Assign units to pallets via inspection.</div>
+          ) : (
+            <div className="grid gap-2.5" style={{ gridTemplateColumns: "repeat(auto-fill, minmax(180px, 1fr))" }}>
+              {pallets.map((p) => (
+                <div
+                  key={p.pallet}
+                  onClick={() => p.ready > 0 && selectPallet(p.pallet)}
+                  className={`border rounded-lg p-3.5 ${p.ready === 0 ? "opacity-55 cursor-not-allowed bg-gray-50" : "cursor-pointer hover:border-purple-500 hover:bg-purple-50"} ${currentPallet === p.pallet ? "border-purple-700 bg-purple-100" : "border-gray-300 bg-gray-50"}`}
+                >
+                  <div className="font-bold text-gray-800 mb-1">{p.pallet}</div>
+                  <div className="flex gap-2 flex-wrap text-xs">
+                    <span className="px-1.5 py-0.5 rounded-full font-semibold text-emerald-800 bg-emerald-100">{p.ready} ready</span>
+                    {p.shipped > 0 && <span className="px-1.5 py-0.5 rounded-full font-semibold text-purple-800 bg-purple-100">{p.shipped} shipped</span>}
+                    <span className="px-1.5 py-0.5 rounded-full font-semibold text-gray-600 bg-gray-100">{p.total} total</span>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {currentPallet && (
+          <div className={card}>
+            <h2 className="text-base font-bold mb-2">2. Choose units to ship</h2>
+            <div className="flex gap-3 mb-2.5 text-sm">
+              <button onClick={selectAll} className="text-blue-500 font-semibold hover:underline">Select all ready</button>
+              <button onClick={selectNone} className="text-blue-500 font-semibold hover:underline">Select none</button>
+            </div>
+            {loadingUnits ? (
+              <div className="text-center text-gray-500 py-5">Loading units…</div>
+            ) : units.length === 0 ? (
+              <div className="text-center text-gray-500 py-5">No units on this pallet.</div>
+            ) : (
+              units.map((u) => {
+                const canShip = !u.shipDate && !!u.inspectionDate;
+                return (
+                  <div key={u.id} className={`flex items-center gap-3 px-3 py-2.5 border rounded-lg mb-1.5 ${u.shipDate ? "bg-gray-50 opacity-70" : "bg-white border-gray-200"}`}>
+                    <input type="checkbox" disabled={!canShip} checked={!!selected[u.id] && canShip} onChange={() => toggle(u.id)} className="w-4 h-4" />
+                    <span className="font-mono text-xs font-bold text-purple-800 bg-purple-100 px-2 py-1 rounded">{u.fileNo || u.id}</span>
+                    <div className="flex-1">
+                      <div className="text-sm text-gray-800">{u.laptop || "(no laptop name)"}</div>
+                      <div className="text-xs text-gray-500">
+                        {[u.serial && `SN: ${u.serial}`, u.inspectionDate && `Insp: ${u.inspectionDate}`, u.shipDate && `Shipped: ${u.shipDate}${u.shipBatch ? " · " + u.shipBatch : ""}`].filter(Boolean).join(" · ") || "(no details)"}
+                      </div>
+                    </div>
+                    <span className={`text-xs px-2 py-0.5 rounded-full font-semibold ${u.shipDate ? "text-purple-800 bg-purple-100" : u.inspectionDate ? "text-emerald-800 bg-emerald-100" : "text-amber-800 bg-amber-100"}`}>
+                      {u.shipDate ? "shipped" : u.inspectionDate ? "ready" : "not inspected"}
+                    </span>
+                  </div>
+                );
+              })
+            )}
+          </div>
+        )}
+
+        {currentPallet && (
+          <div className={card}>
+            <h2 className="text-base font-bold mb-2">3. Confirm shipment</h2>
+            <div className="text-sm text-gray-600 bg-gray-50 border border-gray-200 rounded p-3 mb-3.5">
+              <strong>{selectedIds.length}</strong> unit{selectedIds.length === 1 ? "" : "s"} selected from <strong>{currentPallet}</strong>
+              {selectedIds.length === readyIds.length ? " (whole pallet)" : " (partial)"}.
+            </div>
+            <label className="block text-sm font-bold mb-1.5">Ship Date<span className="text-red-600">*</span></label>
+            <input type="date" value={shipDate} max={new Date().toISOString().slice(0, 10)} onChange={(e) => setShipDate(e.target.value)} className="w-full max-w-xs p-2.5 border border-gray-300 rounded text-sm" />
+            <button onClick={ship} disabled={shipping || !selectedIds.length} className="mt-4 w-full bg-purple-500 text-white py-3 rounded font-semibold hover:bg-purple-600 disabled:bg-gray-400">
+              {shipping ? "Shipping…" : "📦 Ship Selected Units"}
+            </button>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}
+
+export default ReturnsShipOut;


### PR DESCRIPTION
## Summary

Replaces the SnowBell Return page with the new **Returns (RMA)** workflow — a Flask port of the Snowbell RMA Google Apps Script — and brings its UI in line with the rest of the app.

## What changed

### Returns (RMA) feature
- New `/returns` backend blueprint reusing `RMA_return_receiving` (rows tagged `Source = 'RETURNS'`, so the existing `/return` feature is untouched). Supports multi-unit submissions under one tracking number (per-unit laptop names, photos, auto-assigned File Nos), inspection with pallet assignment, batch ship-out, and a monthly report.
- Dashboard: the SnowBell Return button is replaced by Returns (RMA). The `/xie` routes remain reachable (Return Receiving details still links there for SnowBell items).
- Migration `2026-07_add_returns_columns.sql` adds the new nullable columns + indexes (safe to run repeatedly).

### UI/UX
- Returns pages restyled to match the app-wide conventions (`GenericList`/`GenericForm` look): sortable grouped table with expandable tracking groups (purple spine + unit labels on children), click-to-copy cells with toast, column visibility filter, standard button row.
- Input page: scanner-safe (Enter no longer submits), autofocus on tracking, quantity stepper, "apply name to all units", removable image previews.
- Detail page: status chip, inspection date defaults to today, pallet autocomplete from existing pallets, barcode label printing that prints only the barcode + File No.

### Fixes
- **Register endpoint** no longer reports "Username already exists" for every DB failure — it now distinguishes missing fields (400 listing them), true duplicates (409, checked explicitly), connection failures, and other DB errors (500 with the cause).
- **Returns list performance**: the image-count lookup now scans the images directory once per request instead of hitting the filesystem once per row (3k+ rows).

### Local development
- `backend/migrations/local_dev_bootstrap.sql` creates the `RMA` database and every table the backend queries, for a fresh local environment.
- `config.py` gains optional `TRUSTED_CONNECTION` support (Windows auth for local SQL Server Express); production config remains the active one, with the local variant as a commented block.

## Notes for review
- `RMA_return_receiving` is shared between the old `/return` feature (`Source IS NULL`) and the new Returns feature (`Source = 'RETURNS'`); every new query filters on `Source`.
- Table schemas in the bootstrap script were inferred from the app's SQL statements — production may have extra columns; the script is for local dev only.
- Frontend production build passes; the only ESLint warnings are pre-existing ones in untouched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
